### PR TITLE
Add widget that displays widgets

### DIFF
--- a/reference/03.00-widget-list.ipynb
+++ b/reference/03.00-widget-list.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Widgets in the core ipywidgets package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The package `ipywidgets` provides two things:\n",
+    "\n",
+    "+ A communication framework between the front end (your browser) and back end (python or other kernel).\n",
+    "+ A set of fundamental user interface elements like buttons and checkboxes.\n",
+    "\n",
+    "The next couple of cells create a browser of the available elements. To see more detail about any of the elements click on its title. It will be easier to view both the overview and the detail if you have them open in separate tabs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from widget_org import organized_widgets, list_overview_widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instructions\n",
+    "\n",
+    "Run the cell below. Click on the name of any widget to see a more detailed example of using the widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groups = organized_widgets(organize_by='ui')\n",
+    "help_url_base='complete-ipywidgets-widget-list.ipynb'\n",
+    "list_overview_widget(groups, columns=2, min_width_single_widget=200, help_url_base=help_url_base)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "You may not have time to finish all of these exercises."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Fix the example from the previous notebook\n",
+    "\n",
+    "The code below is taken from the previous notebook of this tutorial. \n",
+    "\n",
+    "Run the code below then try typing a number larger than 10 or smaller than 5 into the text box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slider = widgets.FloatSlider(\n",
+    "    value=7.5,\n",
+    "    min=5.0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Input:',\n",
+    ")\n",
+    "\n",
+    "# Create text box to hold slider value\n",
+    "text = widgets.FloatText(description='Value')\n",
+    "\n",
+    "# Link slider value and text box value\n",
+    "widgets.link((slider, 'value'), (text, 'value'))\n",
+    "\n",
+    "# Put them in a vertical box\n",
+    "widgets.VBox([slider, text])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the slider has the wrong value! The slider has a minimum and maximum value but the text box doesn't.\n",
+    "\n",
+    "Replace the `FloatText` in the code above with a text widget that has a minimum and maximum that matches the slider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load solutions/bounded-float-text.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Two widgets in a box and link them\n",
+    "\n",
+    "Put two widgets, the `Play` widget and a widget of your choice that can hold an integer, in a horizontal box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load solutions/widgets-in-a-box.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Link the values of the two widgets above so that changing the value of one affects the value of the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Try tabs or accordions\n",
+    "\n",
+    "Choose two or more widgets and place them in either different tabs or accordions. Set the name of each tab or accordion to something more meaningful than the default names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set which tab or accordion is selected by typing the right code in the cell below (hint, look at the `selected_index` attribute)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/reference/complete-ipywidgets-widget-list.ipynb
+++ b/reference/complete-ipywidgets-widget-list.ipynb
@@ -1,0 +1,3160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Widget List"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Numeric widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are many widgets distributed with ipywidgets that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IntSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.IntSlider(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Test:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='d'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### FloatSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatSlider(\n",
+    "    value=7.5,\n",
+    "    min=0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Test:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.1f',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sliders can also be **displayed vertically**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatSlider(\n",
+    "    value=7.5,\n",
+    "    min=0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Test:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='vertical',\n",
+    "    readout=True,\n",
+    "    readout_format='.1f',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FloatLogSlider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `FloatLogSlider` has a log scale, which makes it easy to have a slider that covers a wide range of positive magnitudes. The `min` and `max` refer to the minimum and maximum exponents of the `base`, and the `value` refers to the actual value of the slider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatLogSlider(\n",
+    "    value=10,\n",
+    "    base=10,\n",
+    "    min=-10, # max exponent of base\n",
+    "    max=10, # min exponent of base\n",
+    "    step=0.2, # exponent step\n",
+    "    description='Log Slider'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IntRangeSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.IntRangeSlider(\n",
+    "    value=[5, 7],\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Test:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='d',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FloatRangeSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatRangeSlider(\n",
+    "    value=[5, 7.5],\n",
+    "    min=0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Test:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.1f',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IntProgress"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.IntProgress(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Loading:',\n",
+    "    bar_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
+    "    orientation='horizontal'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### FloatProgress"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatProgress(\n",
+    "    value=7.5,\n",
+    "    min=0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Loading:',\n",
+    "    bar_style='info',\n",
+    "    orientation='horizontal'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The numerical text boxes that impose some limit on the data (range, integer-only) impose that restriction when the user presses enter.\n",
+    "\n",
+    "### BoundedIntText"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.BoundedIntText(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Text:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### BoundedFloatText"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.BoundedFloatText(\n",
+    "    value=7.5,\n",
+    "    min=0,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Text:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IntText"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.IntText(\n",
+    "    value=7.5,\n",
+    "    description='Any:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### FloatText"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.FloatText(\n",
+    "    value=7.5,\n",
+    "    description='Any:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Boolean widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three widgets that are designed to display a boolean value."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ToggleButton"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.ToggleButton(\n",
+    "    value=False,\n",
+    "    description='Click me',\n",
+    "    disabled=False,\n",
+    "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
+    "    tooltip='Description',\n",
+    "    icon='check'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Checkbox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description='Check me',\n",
+    "    disabled=False,\n",
+    "    indent=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Valid\n",
+    "\n",
+    "The valid widget provides a read-only indicator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Valid(\n",
+    "    value=True,\n",
+    "    description='Valid!',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Selection widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the labels are derived by calling `str`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Dropdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Dropdown(\n",
+    "    options=['1', '2', '3'],\n",
+    "    value='2',\n",
+    "    description='Number:',\n",
+    "    disabled=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following is also valid, displaying the words `'One', 'Two', 'Three'` as the dropdown choices but returning the values `1, 2, 3`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Dropdown(\n",
+    "    options=[('One', 1), ('Two', 2), ('Three', 3)],\n",
+    "    value=2,\n",
+    "    description='Number:',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### RadioButtons\n",
+    "\n",
+    "Note that the label for this widget is truncated; we will return later to how to allow longer labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.RadioButtons(\n",
+    "    options=['pepperoni', 'pineapple', 'anchovies'],\n",
+    "#     value='pineapple',\n",
+    "    description='Pizza topping:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Select(\n",
+    "    options=['Linux', 'Windows', 'OSX'],\n",
+    "    value='OSX',\n",
+    "    # rows=10,\n",
+    "    description='OS:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SelectionSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.SelectionSlider(\n",
+    "    options=['scrambled', 'sunny side up', 'poached', 'over easy'],\n",
+    "    value='sunny side up',\n",
+    "    description='I like my eggs ...',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SelectionRangeSlider\n",
+    "\n",
+    "The value, index, and label keys are 2-tuples of the min and max values selected. The options must be nonempty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "import datetime\n",
+    "dates = [datetime.date(2015,i,1) for i in range(1,13)]\n",
+    "options = [(i.strftime('%b'), i) for i in dates]\n",
+    "widgets.SelectionRangeSlider(\n",
+    "    options=options,\n",
+    "    index=(0,11),\n",
+    "    description='Months (2015)',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### ToggleButtons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.ToggleButtons(\n",
+    "    options=['Slow', 'Regular', 'Fast'],\n",
+    "    description='Speed:',\n",
+    "    disabled=False,\n",
+    "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
+    "    tooltips=['Description of slow', 'Description of regular', 'Description of fast'],\n",
+    "#     icons=['check'] * 3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SelectMultiple\n",
+    "Multiple values can be selected with <kbd>shift</kbd> and/or <kbd>ctrl</kbd> (or <kbd>command</kbd>) pressed and mouse clicks or arrow keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.SelectMultiple(\n",
+    "    options=['Apples', 'Oranges', 'Pears'],\n",
+    "    value=['Oranges'],\n",
+    "    #rows=10,\n",
+    "    description='Fruits',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## String widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several widgets that can be used to display a string value.  The `Text` and `Textarea` widgets accept input. The `Password` widget is a special `Text` widget that hides its input.  The `HTML` and `HTMLMath` widgets display a string as HTML (`HTMLMath` also renders math). The `Label` widget can be used to construct a custom control label."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Text(\n",
+    "    value='Hello World',\n",
+    "    placeholder='Type something',\n",
+    "    description='String:',\n",
+    "    disabled=False   \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Textarea"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Textarea(\n",
+    "    value='Hello World',\n",
+    "    placeholder='Type something',\n",
+    "    description='String:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Password"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Password(\n",
+    "    value='password',\n",
+    "    placeholder='Enter password',\n",
+    "    description='Password:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combobox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Combobox(\n",
+    "    options=['One', 'Two', 'Three'],\n",
+    "    description='Select or type',\n",
+    "    placeholder='Type here',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Label\n",
+    "\n",
+    "The `Label` widget is useful if you need to build a custom description next to a control using similar styling to the built-in control descriptions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.HBox([widgets.Label(value=\"The $m$ in $E=mc^2$:\"), widgets.FloatSlider()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.HTML(\n",
+    "    value=\"Hello <b>World</b>\",\n",
+    "    placeholder='Some HTML',\n",
+    "    description='Some HTML',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HTMLMath"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.HTMLMath(\n",
+    "    value=r\"Some math and <i>HTML</i>: \\(x^2\\) and $$\\frac{x+1}{x-1}$$\",\n",
+    "    placeholder='Some HTML',\n",
+    "    description='Some HTML',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "file = open(\"../images/WidgetArch.png\", \"rb\")\n",
+    "image = file.read()\n",
+    "widgets.Image(\n",
+    "    value=image,\n",
+    "    format='png',\n",
+    "    width=300,\n",
+    "    height=400,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Button"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Button(\n",
+    "    description='Click me',\n",
+    "    disabled=False,\n",
+    "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
+    "    tooltip='Click me',\n",
+    "    icon='check'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output\n",
+    "\n",
+    "The `Output` widget can capture and display stdout, stderr and [rich output generated by IPython](http://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#module-IPython.display). After the widget is created, direct output to it using a context manager."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "out = widgets.Output()\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can print text to the output area as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with out:\n",
+    "    for i in range(10):\n",
+    "        print(i, 'Hello world!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rich material can also be directed to the output area. Anything which displays nicely in a Jupyter notebook will also display well in the `Output` widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import YouTubeVideo\n",
+    "with out:\n",
+    "    display(YouTubeVideo('eWzY2nGfkXk'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Play \n",
+    "### An animation widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Play` widget is useful to perform animations by iterating on a sequence of integers with a certain speed. The value of the slider below is linked to the player."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "play = widgets.Play(\n",
+    "#     interval=10,\n",
+    "    value=50,\n",
+    "    min=0,\n",
+    "    max=100,\n",
+    "    step=1,\n",
+    "    description=\"Press play\",\n",
+    "    disabled=False\n",
+    ")\n",
+    "slider = widgets.IntSlider()\n",
+    "widgets.jslink((play, 'value'), (slider, 'value'))\n",
+    "widgets.HBox([play, slider])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Video\n",
+    "\n",
+    "The `value` of this widget accepts a byte string.  The byte string is the\n",
+    "raw video data that you want the browser to display.  You can explicitly\n",
+    "define the format of the byte string using the `format` trait (which\n",
+    "defaults to \"mp4\").\n",
+    "\n",
+    "#### Displaying YouTube videos\n",
+    "\n",
+    "Though it is possible to stream a YouTube video in the `Video` widget, there is an easier way using the  `Output` widget and the IPython `YouTubeVideo` display. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "f = open('../Big.Buck.Bunny.mp4', 'rb')\n",
+    "widgets.Video(\n",
+    "    value=f.read(),\n",
+    "    format='mp4'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Audio\n",
+    "\n",
+    "The `value` of this widget accepts a byte string.  The byte string is the\n",
+    "raw audio data that you want the browser to display.  You can explicitly\n",
+    "define the format of the byte string using the `format` trait (which\n",
+    "defaults to \"mp3\").\n",
+    "\n",
+    "If you pass `\"url\"` to the `\"format\"` trait, `value` will be interpreted\n",
+    "as a URL as bytes encoded in UTF-8."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "f = open('../invalid_keypress.mp3', 'rb')\n",
+    "widgets.Audio(\n",
+    "    value=f.read(),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DatePicker\n",
+    "\n",
+    "The date picker widget works in Chrome, Firefox and IE Edge, but does not currently work in Safari because it does not support the HTML date input field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.DatePicker(\n",
+    "    description='Pick a Date',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ColorPicker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.ColorPicker(\n",
+    "    concise=False,\n",
+    "    description='Pick a color',\n",
+    "    value='blue',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FileUpload\n",
+    "\n",
+    "The `FileUpload` allows to upload any type of file(s) as bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "a = widgets.FileUpload(\n",
+    "    accept='',  # Accepted file extension e.g. '.txt', '.pdf', 'image/*', 'image/*,.pdf'\n",
+    "    multiple=False,  # True to accept multiple files upload else False\n",
+    ")\n",
+    "a\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The file contents are available in `a.value` for a single upload. For multiple uploads `a.value` is a dictionary where the keys are the file names and the values are the file contents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controller\n",
+    "\n",
+    "The `Controller` allows a game controller to be used as an input device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Controller(\n",
+    "    index=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Container/Layout widgets\n",
+    "\n",
+    "These widgets are used to hold other widgets, called children. Each has a `children` property that may be set either when the widget is created or later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "items = [widgets.Label(str(i)) for i in range(4)]\n",
+    "widgets.Box(items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HBox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "items = [widgets.Label(str(i)) for i in range(4)]\n",
+    "widgets.HBox(items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### VBox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "items = [widgets.Label(str(i)) for i in range(4)]\n",
+    "left_box = widgets.VBox([items[0], items[1]])\n",
+    "right_box = widgets.VBox([items[2], items[3]])\n",
+    "widgets.HBox([left_box, right_box])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GridBox\n",
+    "\n",
+    "This box uses the CSS Grid Layout specification to lay out its children in two dimensional grid. The example below lays out the 8 items inside in 3 columns and as many rows as needed to accommodate the items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "items = [widgets.Label(str(i)) for i in range(8)]\n",
+    "widgets.GridBox(items, layout=widgets.Layout(grid_template_columns=\"repeat(3, 100px)\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accordion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "accordion = widgets.Accordion(children=[widgets.IntSlider(), widgets.Text()])\n",
+    "accordion.set_title(0, 'Slider')\n",
+    "accordion.set_title(1, 'Text')\n",
+    "accordion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tab\n",
+    "\n",
+    "In this example the children are set after the tab is created. Titles for the tabs are set in the same way they are for `Accordion`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "tab_contents = ['P0', 'P1', 'P2', 'P3', 'P4']\n",
+    "children = [widgets.Text(description=name) for name in tab_contents]\n",
+    "tab = widgets.Tab()\n",
+    "tab.children = children\n",
+    "for i in range(len(children)):\n",
+    "    tab.set_title(i, str(i))\n",
+    "tab"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accordion and Tab use `selected_index`, not value\n",
+    "\n",
+    "Unlike the rest of the widgets discussed earlier, the container widgets `Accordion` and `Tab` update their `selected_index` attribute when the user changes which accordion or tab is selected. That means that you can both see what the user is doing *and* programmatically set what the user sees by setting the value of `selected_index`.\n",
+    "\n",
+    "Setting `selected_index = None` closes all of the accordions or deselects all tabs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the cells below try displaying or setting the `selected_index` of the `tab` and/or `accordion`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.selected_index = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accordion.selected_index = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nesting tabs and accordions\n",
+    "\n",
+    "Tabs and accordions can be nested as deeply as you want. If you have a few minutes, try nesting a few accordions or putting an accordion inside a tab or a tab inside an accordion. \n",
+    "\n",
+    "The example below makes a couple of tabs with an accordion children in one of them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "tab_nest = widgets.Tab()\n",
+    "tab_nest.children = [accordion, accordion]\n",
+    "tab_nest.set_title(0, 'An accordion')\n",
+    "tab_nest.set_title(1, 'Copy of the accordion')\n",
+    "tab_nest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TwoByTwoLayout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can easily create a layout with 4 widgets aranged on 2x2 matrix using the `TwoByTwoLayout` widget: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import TwoByTwoLayout, Button, Layout\n",
+    "\n",
+    "\n",
+    "TwoByTwoLayout(top_left=Button(description=\"Top left\"),\n",
+    "               top_right=Button(description=\"Top right\"),\n",
+    "               bottom_left=Button(description=\"Bottom left\"),\n",
+    "               bottom_right=Button(description=\"Bottom right\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AppLayout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`AppLayout` is a widget layout template that allows you to create an application-like widget arrangements. It consist of a header, a footer, two sidebars and a central pane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import AppLayout, Button, Layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header        = Button(description=\"Header\",\n",
+    "                       layout=Layout(width=\"auto\", height=\"auto\"))\n",
+    "left_sidebar  = Button(description=\"Left Sidebar\",\n",
+    "                       layout=Layout(width=\"auto\", height=\"auto\"))\n",
+    "center        = Button(description=\"Center\",\n",
+    "                       layout=Layout(width=\"auto\", height=\"auto\"))\n",
+    "right_sidebar = Button(description=\"Right Sidebar\", \n",
+    "                       layout=Layout(width=\"auto\", height=\"auto\"))\n",
+    "footer        = Button(description=\"Footer\", \n",
+    "                       layout=Layout(width=\"auto\", height=\"auto\"))\n",
+    "\n",
+    "AppLayout(header=header,\n",
+    "          left_sidebar=left_sidebar,\n",
+    "          center=center,\n",
+    "          right_sidebar=right_sidebar,\n",
+    "          footer=footer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GridspecLayout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`GridspecLayout` is a N-by-M grid layout allowing for flexible layout definitions using an API similar to matplotlib's [GridSpec](https://matplotlib.org/tutorials/intermediate/gridspec.html#sphx-glr-tutorials-intermediate-gridspec-py).\n",
+    "\n",
+    "You can use `GridspecLayout` to define a simple regularly-spaced grid. For example, to create a 4x3 layout:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import GridspecLayout, Button, Layout\n",
+    "\n",
+    "grid = GridspecLayout(4, 3)\n",
+    "\n",
+    "for i in range(4):\n",
+    "    for j in range(3):\n",
+    "        grid[i, j] = Button(layout=Layout(width='auto', height='auto'))\n",
+    "grid"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "widgets-tutorial",
+   "language": "python",
+   "name": "widgets-tutorial"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0003bd8881b545ad8fb141d18645c7a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "003f197d4557427c834c6489193761c7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0071b727b14d42178ee5f8847e94f406": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "04afd6d9ea954058a9e2913f58d35e67": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SelectionRangeSliderModel",
+      "state": {
+       "_model_name": "SelectionRangeSliderModel",
+       "_options_labels": [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec"
+       ],
+       "_view_name": "SelectionRangeSliderView",
+       "description": "Months (2015)",
+       "index": [
+        0,
+        11
+       ],
+       "layout": "IPY_MODEL_474e4887b3804400b2e8b16f81dab607",
+       "style": "IPY_MODEL_d58522711a194316a0ce902c67c6e6fe"
+      }
+     },
+     "059fa422e97a40d2952de3c83f3eeeab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TabModel",
+      "state": {
+       "_titles": {
+        "0": "0",
+        "1": "1",
+        "2": "2",
+        "3": "3",
+        "4": "4"
+       },
+       "children": [
+        "IPY_MODEL_d3590a9f39dc48da89cb648b571d26c9",
+        "IPY_MODEL_3af576e98b2849b8b0297dae003fd8e1",
+        "IPY_MODEL_466d571f5f6f49018a6f721d561d930e",
+        "IPY_MODEL_7646344abe9541baa5cfdcc22a56655a",
+        "IPY_MODEL_cd17431a00f143b38bcd0fe4fe135df1"
+       ],
+       "layout": "IPY_MODEL_5b63e849ede84a6c9ed4a64d6ea76500",
+       "selected_index": 3
+      }
+     },
+     "05dd075f9fdb424c95356871a054a93a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "09c2d1294b1d48ea96982a307a53f529": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "layout": "IPY_MODEL_ef674bc6a53049fdac81eefc1fe97047",
+       "style": "IPY_MODEL_314095892d6a4d409c628b0d3760efd0",
+       "value": 50
+      }
+     },
+     "11eb8e2d33354913bb0b3ae8a8360a62": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1367e79137ba4276ba7b01e7a060b692": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "180d46cb59854bacb0451fa48e0a746f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "18e9b06c0d824dd697826754af6aa889": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "19f7f65a07cf4edca7a3b85e920ca4b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_d8225b7fc20446968e0d95052ebac7f1",
+       "style": "IPY_MODEL_44f766c5b641462fa7bc8d7178b264bf",
+       "value": "3"
+      }
+     },
+     "1e8cb22616f14fbdb570d965d017aab0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1ecb7c29ca0d4d08a61df5578b47c092": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ImageModel",
+      "state": {
+       "_b64value": "iVBORw0KGgoAAAANSUhEUgAAATIAAAGxCAYAAADh4jqzAAAKQWlDQ1BJQ0MgUHJvZmlsZQAASA2dlndUU9kWh8+9N73QEiIgJfQaegkg0jtIFQRRiUmAUAKGhCZ2RAVGFBEpVmRUwAFHhyJjRRQLg4Ji1wnyEFDGwVFEReXdjGsJ7601896a/cdZ39nnt9fZZ+9917oAUPyCBMJ0WAGANKFYFO7rwVwSE8vE9wIYEAEOWAHA4WZmBEf4RALU/L09mZmoSMaz9u4ugGS72yy/UCZz1v9/kSI3QyQGAApF1TY8fiYX5QKUU7PFGTL/BMr0lSkyhjEyFqEJoqwi48SvbPan5iu7yZiXJuShGlnOGbw0noy7UN6aJeGjjAShXJgl4GejfAdlvVRJmgDl9yjT0/icTAAwFJlfzOcmoWyJMkUUGe6J8gIACJTEObxyDov5OWieAHimZ+SKBIlJYqYR15hp5ejIZvrxs1P5YjErlMNN4Yh4TM/0tAyOMBeAr2+WRQElWW2ZaJHtrRzt7VnW5mj5v9nfHn5T/T3IevtV8Sbsz55BjJ5Z32zsrC+9FgD2JFqbHbO+lVUAtG0GQOXhrE/vIADyBQC03pzzHoZsXpLE4gwnC4vs7GxzAZ9rLivoN/ufgm/Kv4Y595nL7vtWO6YXP4EjSRUzZUXlpqemS0TMzAwOl89k/fcQ/+PAOWnNycMsnJ/AF/GF6FVR6JQJhIlou4U8gViQLmQKhH/V4X8YNicHGX6daxRodV8AfYU5ULhJB8hvPQBDIwMkbj96An3rWxAxCsi+vGitka9zjzJ6/uf6Hwtcim7hTEEiU+b2DI9kciWiLBmj34RswQISkAd0oAo0gS4wAixgDRyAM3AD3iAAhIBIEAOWAy5IAmlABLJBPtgACkEx2AF2g2pwANSBetAEToI2cAZcBFfADXALDIBHQAqGwUswAd6BaQiC8BAVokGqkBakD5lC1hAbWgh5Q0FQOBQDxUOJkBCSQPnQJqgYKoOqoUNQPfQjdBq6CF2D+qAH0CA0Bv0BfYQRmALTYQ3YALaA2bA7HAhHwsvgRHgVnAcXwNvhSrgWPg63whfhG/AALIVfwpMIQMgIA9FGWAgb8URCkFgkAREha5EipAKpRZqQDqQbuY1IkXHkAwaHoWGYGBbGGeOHWYzhYlZh1mJKMNWYY5hWTBfmNmYQM4H5gqVi1bGmWCesP3YJNhGbjS3EVmCPYFuwl7ED2GHsOxwOx8AZ4hxwfrgYXDJuNa4Etw/XjLuA68MN4SbxeLwq3hTvgg/Bc/BifCG+Cn8cfx7fjx/GvyeQCVoEa4IPIZYgJGwkVBAaCOcI/YQRwjRRgahPdCKGEHnEXGIpsY7YQbxJHCZOkxRJhiQXUiQpmbSBVElqIl0mPSa9IZPJOmRHchhZQF5PriSfIF8lD5I/UJQoJhRPShxFQtlOOUq5QHlAeUOlUg2obtRYqpi6nVpPvUR9Sn0vR5Mzl/OX48mtk6uRa5Xrl3slT5TXl3eXXy6fJ18hf0r+pvy4AlHBQMFTgaOwVqFG4bTCPYVJRZqilWKIYppiiWKD4jXFUSW8koGStxJPqUDpsNIlpSEaQtOledK4tE20Otpl2jAdRzek+9OT6cX0H+i99AllJWVb5SjlHOUa5bPKUgbCMGD4M1IZpYyTjLuMj/M05rnP48/bNq9pXv+8KZX5Km4qfJUilWaVAZWPqkxVb9UU1Z2qbapP1DBqJmphatlq+9Uuq43Pp893ns+dXzT/5PyH6rC6iXq4+mr1w+o96pMamhq+GhkaVRqXNMY1GZpumsma5ZrnNMe0aFoLtQRa5VrntV4wlZnuzFRmJbOLOaGtru2nLdE+pN2rPa1jqLNYZ6NOs84TXZIuWzdBt1y3U3dCT0svWC9fr1HvoT5Rn62fpL9Hv1t/ysDQINpgi0GbwaihiqG/YZ5ho+FjI6qRq9Eqo1qjO8Y4Y7ZxivE+41smsImdSZJJjclNU9jU3lRgus+0zwxr5mgmNKs1u8eisNxZWaxG1qA5wzzIfKN5m/krCz2LWIudFt0WXyztLFMt6ywfWSlZBVhttOqw+sPaxJprXWN9x4Zq42Ozzqbd5rWtqS3fdr/tfTuaXbDdFrtOu8/2DvYi+yb7MQc9h3iHvQ732HR2KLuEfdUR6+jhuM7xjOMHJ3snsdNJp9+dWc4pzg3OowsMF/AX1C0YctFx4bgccpEuZC6MX3hwodRV25XjWuv6zE3Xjed2xG3E3dg92f24+ysPSw+RR4vHlKeT5xrPC16Il69XkVevt5L3Yu9q76c+Oj6JPo0+E752vqt9L/hh/QL9dvrd89fw5/rX+08EOASsCegKpARGBFYHPgsyCRIFdQTDwQHBu4IfL9JfJFzUFgJC/EN2hTwJNQxdFfpzGC4sNKwm7Hm4VXh+eHcELWJFREPEu0iPyNLIR4uNFksWd0bJR8VF1UdNRXtFl0VLl1gsWbPkRoxajCCmPRYfGxV7JHZyqffS3UuH4+ziCuPuLjNclrPs2nK15anLz66QX8FZcSoeGx8d3xD/iRPCqeVMrvRfuXflBNeTu4f7kufGK+eN8V34ZfyRBJeEsoTRRJfEXYljSa5JFUnjAk9BteB1sl/ygeSplJCUoykzqdGpzWmEtPi000IlYYqwK10zPSe9L8M0ozBDuspp1e5VE6JA0ZFMKHNZZruYjv5M9UiMJJslg1kLs2qy3mdHZZ/KUcwR5vTkmuRuyx3J88n7fjVmNXd1Z752/ob8wTXuaw6thdauXNu5Tnddwbrh9b7rj20gbUjZ8MtGy41lG99uit7UUaBRsL5gaLPv5sZCuUJR4b0tzlsObMVsFWzt3WazrWrblyJe0fViy+KK4k8l3JLr31l9V/ndzPaE7b2l9qX7d+B2CHfc3em681iZYlle2dCu4F2t5czyovK3u1fsvlZhW3FgD2mPZI+0MqiyvUqvakfVp+qk6oEaj5rmvep7t+2d2sfb17/fbX/TAY0DxQc+HhQcvH/I91BrrUFtxWHc4azDz+ui6rq/Z39ff0TtSPGRz0eFR6XHwo911TvU1zeoN5Q2wo2SxrHjccdv/eD1Q3sTq+lQM6O5+AQ4ITnx4sf4H++eDDzZeYp9qukn/Z/2ttBailqh1tzWibakNml7THvf6YDTnR3OHS0/m/989Iz2mZqzymdLz5HOFZybOZ93fvJCxoXxi4kXhzpXdD66tOTSna6wrt7LgZevXvG5cqnbvfv8VZerZ645XTt9nX297Yb9jdYeu56WX+x+aem172296XCz/ZbjrY6+BX3n+l37L972un3ljv+dGwOLBvruLr57/17cPel93v3RB6kPXj/Mejj9aP1j7OOiJwpPKp6qP6391fjXZqm99Oyg12DPs4hnj4a4Qy//lfmvT8MFz6nPK0a0RupHrUfPjPmM3Xqx9MXwy4yX0+OFvyn+tveV0auffnf7vWdiycTwa9HrmT9K3qi+OfrW9m3nZOjk03dp76anit6rvj/2gf2h+2P0x5Hp7E/4T5WfjT93fAn88ngmbWbm3/eE8/syOll+AAAACXBIWXMAABcSAAAXEgFnn9JSAAAB1WlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOkNvbXByZXNzaW9uPjU8L3RpZmY6Q29tcHJlc3Npb24+CiAgICAgICAgIDx0aWZmOlBob3RvbWV0cmljSW50ZXJwcmV0YXRpb24+MjwvdGlmZjpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KsOMy3QAAQABJREFUeAHtXQe4FEW2LhRzQsyCIigGBHNW5HpNmIVdAyZQXMOiu4hZDKiL4ZneGteE7qorCqu4a06AcUXBRUxgQgUDgjkj9Dt/7TtlTc90z8y9U8305T/fd293VzhV/ff0P6eqTp1pFYkYChEgAkQgxwgskOO+s+tEgAgQAYsAiYwfBCJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco9A69B3MGLECDN06FAze/bs0E1RPxEgAnWOQLt27czw4cNN27Zta9tT/K5lSGlsbMTvZvKPGPAzwM+A/QyMHDmy5pQT3CKbM2eOZd4hQ4aYHj161JaFqY0IEIHcIDBw4EAzceJEM3fu3Jr3OTiRaY+7dOliGhoa9JJHIkAE5jME2rRpE+yOOdkfDFoqJgJEICsESGRZIc12iAARCIYAiSwYtFRMBIhAVgiQyLJCmu0QASIQDAESWTBoqZgIEIGsECCRZYU02yECRCAYAiSyYNBSMREgAlkhQCLLCmm2QwSIQDAESGTBoKViIkAEskKARJYV0myHCBCBYAiQyIJBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSFAIssKabZDBIhAMARIZMGgpWIiQASyQoBElhXSbIcIEIFgCJDIgkFLxUSACGSFAIksK6TZDhEgAsEQIJEFg5aKiQARyAoBEllWSLMdIkAEgiHQOphmKm4SAj/88INZbLHFmlQ3iiLTqlWriurOmTPHoK1vv/3WzJo1y3zyySdmjTXWMGuuuWZF9fNY6Ouvv7bYLrTQQk3q/k8//WS+++47Az3A65dffjEbb7yxWWKJJZqkj5VqhwCJrHZYNkvTjz/+aDbffHPz/vvvmxtvvNEccMABFevDC7X33nubF1980bz66qtmpZVWMmPGjDEPPPCAeeuttyxRff755wZ/eBFBYKhTSo466ihz4YUXmp133tnWBTHq3wILLODOkabXW221lfnb3/5mllpqKavyzjvvNMOHDzfvvvuubQ/lWrdubV/4LbbYwuy4447mN7/5TVnSRf9POeUU880335i11lrLHHTQQeawww4zCy+8cKmuF6XNnTvX3H333WbYsGFm3Lhx5quvvjILLrig2XLLLc3AgQPNfvvt5+p88cUX5rbbbjPjx483H3/8scUKeH355ZcWL5AYvijisswyy5jnn3/erLfeevEsXmeJgDycoNKjRw88/Ug+UEHbybvy5557zuIErPbcc097O/LyRLfeemskZJR6e0Iaru79998f+dfQV83fgAEDohEjRlRVB/qvu+4628eHH364orq77bZbNGPGjMT7EosnEmIs0rX99ttHQvqJ9TRDLM1o3333LarvYyGEbYsLqUfrr79+alm/nn8upBpNnz5dm+UxBYGQXMA5MvlU1oPgm18Fwz3Iqaeeavr162e6du1qLQvNjx9hOajMnDnTvPbaa3pZcPSHnThfZZVV7B+GlLBSzj33XHP++eebZZddtqBeuYu1117bCPnaYlOnTnXFMew688wzzeGHH271L7300i7voYceMo2NjQaWTilBP2CJxeWpp54yffv2LWkdaVkhFiOEZ0aNGqVJJY/XXHONTYc1BissLj5eyEP/gdmqq65qhPhM7969zYMPPmiv43V5nS0CHFpmi3dia/5waYUVVrDlRo4caY942TGsAsFgyBcXDEtVZs+ebc477zxzzDHHGLF47HCuTZs2Bn+XXXaZOf30021RsaDM0UcfrdUKjj6RYc4Mw0YMoTA0A+HqHyphSLXtttu64V7btm2dLrS3ww47uGsMZ++9915zxRVX2OEYhsFnn322ufjii10ZnMiXurnnnntsGoalRxxxhJk0aZJ54YUXbNpdd91lNtlkEzvstAneP9w/2sSQWkWsP9OrVy+z8sorm5dfftmMHTvWDr1B4JDll1/efPTRR+add94xmDtUvDD3teSSS9qhZfv27c17771nh8i2Ev/VFwIplmBNskKakzXpYJ0oeeyxx9zQRkjIDp/EInBp8qmJhGAisXiKenzBBRe4ckI6RfmacPPNN7tyaC9J5IV25QYNGpRUrGT6448/7urK3FHJMjJ3Fe211162nBBFhKGdL0I2TofMFbqsm266KVJMhFgiIR2XpydiZbm6Mi8X3XHHHZpVcPz0008jWeQoSCt1sdpqq1l9QtalsplWBQIhuYBDyzr5XvGHUYsvvri1fuQzUtA7DIH69+9fNKzyLTLUTRKdjEd+WjnfIuvUqVOSupLp/vARq6GlBEM23AcEw2hYW748+eST7lLLIQHngwcPtnnTpk0zjzzyiCuHEyxkYEiqMnToUGvJ6rV/XHHFFY1vPfp5/rliloaXX57n8wYBEtm8wb2o1TiR+SSGuSQMfyBPPPGEueWWWwrq+yuQaa4biyyyiKuX5oLgk5G+yK5imRN/Xumzzz5LLC0WkcvDKqovuEfIoosuaue6/LzTTjvN6NBbFkL8LCMWm3WLQOJ2221nTj755IL8plwoZml4NUUv69QWARJZbfFssrY4kcFdQQUvLuabVGCV6IIA0jCPpJJGZP48nF9H6+rRt/Bef/11m4y5J/hOYd4tTeDyoJJEZLCmLr/8clsM81CbbbaZVjHff/+9GT16tL1GuhKJFkD5Qw891F5i4t8XuFioYKHEJ1VNr/aomKXhVa1Olq89Ar++AbXXTY1VIOATE4YxvgWAIRpe3g033NBqBKH4E+T+S5ZGZL6Vpy9oqS76fUE7IBOUx4odfNROPPHEUtVsmt9GnMgmT55sfdSwCotzyJFHHllwr7DG1EKDv1kp2XTTTW0ycMAKpYqSbocOHcwee+yhyc066v2k4dWsBli5JgiQyGoCY/OVpFlkIDJYFxdddJFrCBbahx9+aK996y2NyH7++WdXH6txSeL3BWX8erieMmUKDiXFt8jQx4022sj+wapcd911zRlnnGHn/1C5oaHBXHrppQV6xA/OXcPNwRcMobG6+Oyzz7rkl156yZ6jXSVHOBbXwhqDYr33NLxcZ3gyzxD4dfwyz7rAhoGATx6YG/LJSSfNe/bsaed+nnnmGWu1YGL7hhtuMMstt5wDUa0Zl+Cd6EuJpDQLw7fI4HbRvXt367UPIgG5HHfccZ7WwlO1YJAKcpk4cWJBgY4dOxpZsTS77LKLwf3A094XePOrYI7rkksuMRjqYlsQMPL1oxyIbJ999rF5eu/qVqF6mnNUzNLwao5+1q0NAiSy2uDYbC0+kWEo5w8tfYfXs846y+y66662vb/+9a/mnHPOMViBU8ELnyT6UiIfK3xJ4hMZ/Lmw2FCp+BYZfK8w6Q4rS3WCBMWlo6Q6OPL6Q0XcS9r9QIlaZCBc+H/Bx833ISvZUBWJilkaXlWoY9FACHBoGQjYatXGiQxDI537AgnAURMCSwb7FSF4ya6//nq3ioc0OK0mib6UyE8jCCUdlNtggw1wqFi0z6iAoSX2XcIJFcNKCBYqlHxsgvcP5XyB9QfHV3jpY74MzsC4d98VAk6yaqXphve4O4evs9pzxSwNr2p1snztESCR1R7TJmn0yQNDS4hvlfn5mGdSwUZn3x8q7YXTlxJ1feJUXXr029K0So9+n3XYiA3fY2QTO44YJu6+++4l59leeeUV1wx2J8A6wyZueOKLo6159NFHrXf/22+/bWDtQeBbhx0CECwiQLBZHe3VQhSzNLxq0Q51NA8BElnz8KtZbf9FUZcDf57MJyhEulALRzz9jU8AtbDI/GFU0l7IpBv3+4xVRRWsdsKBFf5wWM2EZekPI1HOn0/DPsYkweop9luqqBuG7zyLlVW11LRcU45KZD7+TdHDOmERIJGFxbdi7T55qFXjk4JPdBh2+vNM6u2Oxnzn2Hjj8AVT8fVpmh79eS5sQq9G/D7HN2JjlwDm3HB/CFeEuT5YVCo+kcnWIE0uefTn7XQVE4sS3bp1s+UnTJhgjj/+eDckjyuBFQfLVq25eL5eK2ZpeGlZHucdApzsn3fYF7TsuwsokekRBeMvEvzKsGoJFwyQgkqam4DfRlyf1sdRh7Y4R2y0Aw880A4JsegA4tEjSBPDWliH2JgNZ1W/z75FBl0QkA3m9bARHJP7iJqBYSMcbdXbH7sJ/N0F/61Z+B9zZyoSAklPrTc/YpZBEN0CLhlXXXWVs2CR/o9//MNadPjyAFFj5TdJFLM0vJLqMj07BEhk2WGd2pJuu0EhnfPSISbS1DLAOQRkg72E+tL+N9UYuDckib+6CQ/6JPH3WoIMNNxNUnmkg3jgWe9bZLpAEa+HsD5YWUQAR5AQAhxi65EKQuSUE6xQYpgKIgKRg1yBGwgelp3uhABJIkIHhrZwpMX8mu8Hp07GSe0BMwwr1bUjqRzT5y0CHFrOW/xd67o6iAlyeKZD/JA9OrntKsjJIYccYmNiaRqssW222UYvi45wTlXxfc80TY86PNPrSo6wbuBZDzcIlc6dO+tp0REkrBFa4TsmkTlcGV2VdQkJJ34/QVAq8D3r06ePXtojrD3EDvNJDKuiCO+TJoqZfrmklWXePERAJkSDSsjQHUE7nrHyN998MxJHzsgPmyNDr0hiaEXiAZ/YGxnyRBKrLBILJUIIm3IiIaYjce6M5IVOLSqEGMnHMhJijcRajLp06RLhWSJ6rSw2RAivI5PrkcwzRRIfLBKryOkTiysSKyiSYa9LK3UiK5hWD9oRUokk/lqEqK3iAFyqeFGaLB7YviG6qxBpQb4MeyOE/UG/ZXho7wXt4A/3IwErIxn6FtQpdSErppGQmC1fKp9plSMQkgtaoRvycIMJtqFg+Ryx0/UbOFhjLVAx5qHgm+X7Z5W6TUzQlyuj9eBekTaXhnLQp+Uq1av6qzni44dN4quvvrp1z6imLspWct/YGYGFB7QFywqrntXcE6xN+K7pfFm1fWT5/yIQkgs4R1bnnzJ/zimtq9W8mOVIDO1AX7kJ97T+VJoHcvBXICutp+UquW8Mo9OG0qor6YhFDEp9I8A5svp+PuwdESACFSBAIqsAJBYhAkSgvhEgkdX382HviAARqAABElkFILEIESAC9Y0Aiay+nw97RwSIQAUIkMgqAIlFiAARqG8ESGT1/XzYOyJABCpAgERWAUgsQgSIQH0jQCKr7+fD3hEBIlABAiSyCkBiESJABOobARJZfT8f9o4IEIEKECCRVQASixABIlDfCJDI6vv5sHdEgAhUgACJrAKQWIQIEIH6RoBEVt/Ph70jAkSgAgRIZBWAxCJEgAjUNwIksvp+PuwdESACFSBAIqsAJBYhAkSgvhEgkdX382HviAARqAABElkFILEIESAC9Y0Aiay+nw97RwSIQAUIkMgqAIlFiAARqG8ESGT1/XzYOyJABCpAgERWAUgsQgSIQH0jQCKr7+fD3hEBIlABAiSyCkBiESJABOobARJZfT8f9o4IEIEKEGhdQZmaFBk0aJAZMmRITXRRCREgAvlDYOrUqcE6HZzIOnXqZMaOHWumTZsW7CaomAgQgfwgAE6otbSKRGqt1Nc3e/ZsM27cOIMjhQgQgfkbgXbt2pnOnTvXHITgRFbzHlMhESACRCCGACf7Y4DwkggQgfwhQCLL3zNjj4kAEYghQCKLAcJLIkAE8ocAiSx/z4w9JgJEIIYAiSwGCC+JABHIHwIksvw9M/aYCBCBGAIkshggvCQCRCB/CJDI8vfM2GMiQARiCJDIYoDwkggQgfwhQCLL3zNjj4kAEYghQCKLAcJLIkAE8ocAiSx/z4w9JgJEIIYAiSwGCC+JABHIHwLB45GNGDHCDB06lGF88vfZYI+JQM0RQBif4cOHm7Zt29ZWN+KRhZTGxkbEO+MfMeBngJ8B+xkYOXJkzSknuEU2Z84cy7wIc92jR4/asjC1EQEikBsEBg4caCZOnGjmzp1b8z4HJzLtcZcuXUxDQ4Ne8kgEiMB8hkCbNm2C3TEn+4NBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSFAIssKabZDBIhAMARIZMGgpWIiQASyQoBElhXSbIcIEIFgCJDIgkFLxUSACGSFAIksK6TZDhEgAsEQIJEFg5aKiQARyAoBEllWSLMdIkAEgiFAIgsGLRUTASKQFQIksqyQZjtEgAgEQ4BEFgxaKiYCRCArBEhkWSHNdogAEQiGAIksGLRUTASIQFYIkMiyQprtEAEiEAwBElkwaKmYCBCBrBAgkWWFNNshAkQgGAIksmDQUjERIAJZIUAiywpptkMEiEAwBFoH00zFdYnADz/8YBZbbLG67FuoTv3000/mu+++M19//bX55JNPzC+//GI23nhjs8QSS4RqknozRoAWWcaAV9PceeedZzbYYAPz9NNPV1PNlv3222/N9ttvb/bbbz8zZ84cm3bjjTea5ZZbzmyzzTYu7aGHHjINDQ1mvfXWM+3atTNbbbWVOfjgg81ZZ51lRo8eXXW7P/74o7n99ttNr169zFprrWUWX3xxs+KKK5o999zT3HXXXSX1XXHFFWaVVVYxSy+9tGnTpo1ZdtllTdu2bW1fV1hhBVt/pZVWMiuvvLLVOXLkSKfniy++MFdeeaXp27ev2WWXXcxmm21mOnXqZOuDsBdYYAGz6KKLWl0dO3Y0W2+9tenevbu91zfeeMPpAcH96U9/Mttuu63p2rWr2Xvvvc3VV19tic8V4kn9IhAFlh49ekRy99Hdd98duKWWp75z584WOyGzqm/uzDPPtHWB/XPPPWfry4vu0l566SWbtvrqq7s0lI3/denSJZIXOhJrpmwfXn311UhIoEiHr1OItUjP+uuvn1rHr49zITSrQyyrqNq6qmvhhReOpk+fbvVMmzYtUqw1X48LLrhgNHjw4Ojnn38u6jcTqkMgJBfQIpNPbL0KhkSQV155xbz22msVd3P27Nnm+uuvd+Vbt/7vDMKXX37p0mCxwZr54IMPXFqrVq3M2muvbVZbbTWDc8jrr79ujjvuOANr5v7773dl4yd/+ctfzOabb26EzOJZBdcjRowouhdYYJUKLKw//vGPtjj6//HHHxdV1b5rBiw9WHyrrrqqEeIzvXv3Ng8++KC9Rpl99tnHvPXWW1rcWn1CYPYa1uzQoUPNHnvsYeS1dWV4Ul8IcI6svp5HQW/at2/viObRRx+1L2FBgYSLhx9+2Hz22Wc2d5FFFjHdunWz52KFuBoYsoEIfHn55ZfNhhtuaJNAdBha3nHHHQZDuVmzZpm99trLXHvttebYY4/1q1nS9NNAAocccojZYost7DDxP//5jxGr0P4hD2374hPZ+eefb4d1mMcC8eof+oNh8XbbbWc6dOhgqy+//PLmo48+Mu+8844dKmNYij/MfS255JIG84HA8L333jNK5n67OAeu48ePt8kgPFxvueWWZubMmWbAgAFGRhI277HHHrNfKIqPTeS/+kGgOuOw+tIhzcnqe5OvGkcffbQbcgmJVNz5I4880tXbaaedXD2Z/3HpMicUyRyRu5ZPZCQWoCvrnwgxRssss4wti6HWE0884bKhR8jD6RGLLpo4caLL909mzJgRTZkyxU+y54ceeqitL5ZU9NVXXxXlNyVBrEqrE/ecJn369HF9v+6664qKXnrppZF8GUS4L1kwKMpnQuUIhOQCDi3r5zulqCebbLKJS/v3v//tzsudwCJTwZBI5ZtvvtFTOwmPYZovOpzy03C+6667WqsM5xhqnX766Ti1csIJJ1irCRewkDBkwwJFKYElJnNRRVlqkcHiglVUC1lqqaWsGiw2pIlO+MNa7devX1HRE0880chcmrXGyukqqsyEzBDg0DIzqKtvCKtrKhgqTp061ayxxhqaVPKIYZRMXru83Xff3Z03lcigQL5N7XANQ7xx48aZN9980+q98847nf5bb73VrLnmmu660hMlLyWfSuullcOQGrLQQgulFXNzbCBZrG6WEhAspb4RKPxKru++zne9W3fdde28kN64rDTqaeLxqaeecnlwf8DkvYoSGawPWF++RRafINc6egQhyAqmXloi07klJMKlw7f+XMEKTuCyAcF8lwwt7Tl8vt5//32DhYumiM4H+vdYSo9aiLC6MEdIyScCJLI6fm4gF0xuq8jck54mHn2fszixwJqC6BDJJ6+kYaU2NHfuXKPDMKRhRRWT+CoYYibJ999/b1cFn3/+eQOixQqs+rahjvYLOuE/BhKSOTlrfWLy/tNPP01SnZguMzc2TwktqSD8z1R22203c9RRR9nFC/RViV/zeaxfBEhk9ftsbM/84SXcMMoJXkAVf1iJVUC1fJTIfGul3AsPtwr/xYYl4xMZHGnjAlLFiimGjLAMYbVhiAqH03XWWceuJqKOrxeE6VthIEF/qBxvI+la/L5sFlYv0+Twww83ihMIE07DxxxzjO0r5u4wPzhs2LCCPqbpY968QYBENm9wr7jVHXfc0ZWdNGmSOy91gm04OneFOSKfBH2y0LkgkJuKTrjrdfwI9wMVuD9gi8/nn39uk2DNwfM+LiAgECDIKS5wmZBVQpusFhkuNtpoIyMriXZHAo433XST2XTTTePVy14rkZUjaPT9vvvuM5dccoltx5+ng9UId4z+/fvb+8VQl1KfCHCyvz6fi+sV/JawxUdcF+xkP8hK9wjC4gFJwMqBYMimpAELyd9T6ROZToTDz0oFQ7okQd2LL77YZcO/CsNSENqECRPsMBGEBXLzBdt8LrvsMgMrEQSBfsM3TZ171ddNiQxbqsaMGeOccX1d1Z4rkQGvcgIfs5NOOsn+oSzud/LkybavIFssoIB4L7zwQgPHX0r9IUAiq79nUtAjEIb4gpm///3v1rMchAGHzWeffdY0NDTYlx6Ehj2Eb7/9tqvrW3JIbA6RgcSUdLAfE57+EHVMxfmLL75YRGQgrkGDBiHbCSwcDNcgahkqkWEY6s/buUpNOFEiw6JBtQLSxZ5N/PUTlwzs3UQfK5mjrLYtlq8NAhxa1gbHoFqwGVoF82QYEv7ud7+z1heGP+JQajCX5A89GxsbtYo9KlngQgnEt8iSXAxgjWBTt8q5557rLL2ePXtqshHHUetJ7xISTvzFCGx7gvh9S6hWdbISmU/gVSuRCnDLUH8+XVFtih7WCYsAiSwsvjXRvvPOOzs9L7zwgrnhhhsKVhAx7Bk4cKCLVoEJblhtvvgvtA4t/Rczvm0IdeGSAGsQJAnB/BUsFBVYVti7CMFexXPOOUezSh5BwNjypKI+Zzr8072lmt+coxJZmkWGIS62RMGaTBJ8UWD4DMECBaU+ESCR1edzKegVNjuDRCCjRo0yJ598sj3HSqBOsmO1DSQHwTAzvrdQyQL56iQKB1sVDBl9QVgbWHXvvvuuTYbTKvYdxt00MEmuq5+wyuAJn0RImC+DhQdBHb0nndfDfs5aia58+gQe133aaaeZs88+24buwY6EUoIN42oxxucAS5Vn2rxBgHNk8wb3qluFiwDcHfyXHcSA1Ubf1wyKdSjkN+LPPSmR+W4NvuVyzz332IlvJR3ogQuCOo/6euF7hTk0kCt8ty6//HLz+OOP243lsArhRAvCxGZzxA1TwaZytch0qIttWP/85z+tLxk2tOMPK6M4on+wJCXskL3fpG1Qql/vN43I9t13XxvRA6R3wAEHmCeffNJG8IAOWHQgZsSEg+CLAZvmKXWKQOVbPptWMuRG0ab1KJ+1EFNMPkLuD3G4xJKxNyNk4tJRRtwJim7Sry+BE22+rD66emIhRYh75m8Ahy4hj0gIqEhfPGHIkCERdPh9TDqX1dRIXBmcCiG8iur5+sRx1dUvdSK7GqxOmbgvlW3ThMCi3/72t65tcdWIJMRPJEEhI7GCXTraFUJL1MOMyhAIyQX4Fg0qITsftON1plzmaiKN6IAXSywX10NEscBLiHS8uDKJ7/L0RKyaSCwxW0aGUzZZrKyCl9UnCpyD2GQBQVWUPYolVkQAcZ0yPItk5bVAlx+tI14+6VqszgId8QslKFlZjWcVXIPMZOEkEguuJBYylI5klTaS+b2CeryoHoGQXMChpbwpeRDMKZ1xxhl2yCYvacEwB3syMQzCNiGsZupQzb8vbPVBQEKEm0Yoa8hhhx1mJ+kR7BBzYvD4xzwQhqb4gx9YOYdSvw24fGAYiQCMt912m5GQPXZYiNVJePNDJzzpdWirdRHo8JZbbrH+aHDZwMID/rCSiiEdymMBA/N0mBdEH0vtJFB9OB5//PF2qLjDDjv4yUXn0I/FE2CBYSRWVTHBj2Ev5vCAucZzK6rMhLpBoBV4NWRv4Os0duxYO1GM+PGU5iEAz33MVcUn3aHVd5ZtXivZ11ZXEN+Jt7m9AB4gZ50vq0QfFirwpREn20rqskw6AiG5gBZZOvZ1lwvrK0nU4z8pv57Ta0lgep9NwUNdU1QHj/lAgO4X+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCAIksBRxmEQEikA8ESGT5eE7sJREgAikIkMhSwGEWESAC+UCARJaP58ReEgEikIIAiSwFHGYRASKQDwRIZPl4TuwlESACKQiQyFLAYRYRIAL5QIBElo/nxF4SASKQggCJLAUcZhEBIpAPBEhk+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCAIksBRxmEQEikA8ESGT5eE7sJREgAikIkMhSwGEWESAC+UCARJaP58ReEgEikIIAiSwFHGYRASKQDwRIZPl4TuwlESACKQiQyFLAYRYRIAL5QIBElo/nxF4SASKQggCJLAUcZhEBIpAPBEhk+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCQOuUvJpmDRo0yAwZMqSmOqmMCBCB/CAwderUYJ0NTmSdOnUyY8eONdOmTQt2E1RMBIhAfhAAJ9RaWkUitVbq65s9e7YZN26cwZFCBIjA/I1Au3btTOfOnWsOQnAiq3mPqZAIEAEiEEOAk/0xQHhJBIhA/hAgkeXvmbHHRIAIxBAgkcUA4SURIAL5Q4BElr9nxh4TASIQQ4BEFgOEl0SACOQPARJZ/p4Ze0wEiEAMARJZDBBeEgEikD8ESGT5e2bsMREgAjEESGQxQHhJBIhA/hAgkeXvmbHHRIAIxBAgkcUA4SURIAL5Q4BElr9nxh4TASIQQ4BEFgOEl0SACOQPARJZ/p4Ze0wEiEAMgeCBFUeMGGGGDh3KeGQx4HlJBOZHBBCPbPjw4aZt27a1vX0EVgwpjY2NCNzIP2LAzwA/A/YzMHLkyJpTTnCLbM6cOZZ5Ea+/R48etWVhaiMCRCA3CAwcONBMnDjRzJ07t+Z9Dk5k2uMuXbqYhoYGveSRCBCB+QyBNm3aBLtjTvYHg5aKiQARyAoBEllWSLMdIkAEgiFAIgsGLRUTASKQFQIksqyQZjtEgAgEQ4BEFgxaKiYCRCArBEhkWSHNdogAEQiGAIksGLRUTASIQFYIkMiyQprtEAEiEAwBElkwaKmYCBCBrBAgkWWFNNshAkQgGAIksmDQUjERIAJZIUAiywpptkMEiEAwBEhkwaClYiJABLJCgESWFdJshwgQgWAIkMiCQUvFRIAIZIUAiSwrpNkOESACwRAgkQWDloqJABHICgESWVZIsx0iQASCIUAiCwYtFRMBIpAVAiSyrJBmO0SACARDgEQWDFoqJgJEICsESGRZIc12iAARCIYAiSwYtFRMBIhAVgiQyLJCmu0QASIQDAESWTBoqZgIEIGsECCRZYU02yECRCAYAiSyYNBSMREgAlkhQCLLCmm2QwSIQDAESGTBoKViIkAEskKARJYV0nXezi+//GK+/PLLqnsZRZGZO3du1fVYgQjUEgESWS3RzJmud99915xyyilmzTXXNIsuuqhZdtllzQorrGAGDBhgZsyYkXo3b7zxhjnyyCPN8ssvb5ZZZhnTq1cv88EHH5Ss89lnn5lrrrnGfPLJJyXz/cRXXnnF9OvXzwwePNiAXFXuv/9+869//UsvE4+zZ882V1xxhTn44IPNM888k1iOGS0MAflGDSo9evSIBLLo7rvvDtoOlVeHwEMPPRQtvfTS9tng+cT/2rVrF82cObOk0iuvvDJaZJFFiuoIEUavvvpqUZ29997bll155ZWjyZMnF+Vrwq233hotvPDCTu+NN95os1566aWoVatWNn3QoEFavOgohBltu+22rj7ugVI/CITkAlpkLeyLqZLbufrqq82ee+5pvv7668Ti06dPN6NGjSrKv+uuu8wf/vAH89NPP9m8BRb49SP0xRdfWL1fffWVqydkaB588EF7DYtsp512Mh9++KHLx4m8atYCgyX2888/uzxYZ5Dbb7/dlsH55Zdfbs4991ycFsibb75pttxyS/Pss8+6dNzD559/7q550nIR+PVT2HLvkXfmISBWjzn++OPNnDlzbCqGk0OGDDH33HOPueWWW0z//v2NWDI2b4011vBqGjN+/Hhz+OGHu7TTTz/dzqthSHnIIYfY9KlTpxYQzbhx4wqGiCCx3XbbzSjZ/fjjj6ZPnz7mggsucHr1REnIJyfkob833XSTFjOjR482W2+9tcFQOS6qI57O6xaGQGjDM6Q5GbrvLU3/Dz/8EK222mpu6NXQ0BCJlVR0mzI3FU2ZMqUg/fvvv4/at2/v6l500UUF+WJJRZtvvrnNX2ihhZzeq666ytWRV8edr7vuutF1110XdevWzaUhf8kll3TXJ5xwgm1jueWWc2mqY8EFF4wwzDzxxBOj1q1bu3yxEKPFFlvMXQthFvSTF/MOgZBcQIushX0xpd3Otdde64Z1Qmhm5MiRZqWVViqqIiRhOnfuXJA+fPhwM23aNJu2xx57mFNPPbUgX8jLWVWYcL/jjjts/qxZs1y53r17m2222cZeYyh47LHHmkmTJtlrmQMzZ555pnn66addee2bWlVLLLGEgRWIhQlYlBhmXnbZZc7iQ59ffvllO7yFEpSTeUCnjyctFwESWct9tgV3hhffH74NGzbMiKVTUCbtAquOKmeffbaeFhwx/7XhhhvaNAxhITqExTmGkBgG7r///rh0gpXS++67z5x//vkGQ02VFVdc0bp2iA1hkzDUxT3IQoVp06aNFrPHAw44wLz44otmgw02cHN/qE+ZPxBoPX/cJu8S80dqHW266aZ20r1SVDDPhfkxyFZbbWW22GKLxKp9+/Y1MuSzlhasI1hRKt99952RVUkD666xsdEuAkAf5uWUdNT6Qh1YZFhMgGUFgkN9iAyJzQsvvGAuvfRSuzgAEsO8m4rqUItO03lsuQiQyFrusy24s9dff91d//73v3fnlZw88sgjrljPnj3deakTDB9BZJAnn3zSyJyXK/btt9/acwwjjz76aPvnMv//xHfKVXKDDhCZ1kfRtdde29xwww3x6vZadWj9koWY2KIQ4NCyRT3O5JvxiQxuCtXIW2+95YrvvPPO7rzUSYcOHQyGgJAJEyYUENk333xj09P++S4hGHJClAwrqY/yqkPrI43SshEgkbXs5+vuzvfUV6JxmWVO3n77bVeia9eu7jzpBNYS5OOPP3YkhOtKiEjdMlBeRYkMvmtYSCgnpXSUq8P8fCNAIsv386u49z55+RZWJQp0tRLbkSpZBYQjKgRllYRw7Q8NcV1K1JpCnpJWNTpQRxcMtH6pdpjWshAgkbWs55l4N9hPqaIuD3pd7rjOOuvYIpWQGCbk4VoBWWuttQqIrFqLTHcN+ERWTodvjWl92xn+a9EIkMha9OP99ebWX399d3HzzTe780pONttsM1vs/fffd9ZOUj3ZH+lcLvbaay8DnzSVai0y+KZBqtHhW3RaX9vnseUiQCJruc+24M46duxoXR6QOHbsWOu3VVAg5WL77be3ufAJk83/iSVl54C5+OKLbT4swO7du7uJdyTq/sxEBZLhW1TisW+L+uRUTkep+mntMa9lIEAiaxnPsaK7QHgeFbhgYFWxlICw4NoAr3k4o8JHC75bkJNOOslO4tsL7x9C7iB0jobqgeMqhnY+CcGHrJz45UsRWTkdpeqXa5P5+UeARJb/Z1jxHUg4Het/hQofffSR2W677exGcX/IhwgWGBLCz8snLUTMALEgthiGmrDqVLBRHCR277332iQ4uar3vj+nhQ3q5aQUEVWjo1T9cm0yP/8IkMjy/wwrvgMQEULqqKMohoJHHHGEDagIb31428MPDFuAICgnMcTsOebYsLcRVhZIEBbaqquuarBLAMNWHXLCYkJgQxVtC9errLKKJice27Zt6/LU+lId6D9WTtOkVP208sxrGQiQyFrGc6z4LjB39cADDxSsJmJYiH2K2AfpWz8Yfvorfwj/gz2RSy21lG0PfmL+8BST69iIDotMRX3KcL3RRhtpcuJRV0ixtWnxxRe35VRHly5d7BanxMqSoWVRRgkwrTzzWggCoYN6hAzdEbrvLVm/OLlGBx10UCSk5ELeyEc6EuKKxPM/uu222xJvX3YJRAceeKCLEiukE8lwNHr00UdL1pFAiJGQWyQT8SXz/USJVxZJdI1IhrUuWdw5Ilk4iGTjuktLO/nzn/9s7yEeiiitDvPCIxCSC1qh+yE5GUMQzKdg6LHffvuFbIq6m4AAJvaxoRz+X/DXwkZrtbjKqUNdBErEEFOHgeXqMH/+RSAkF3DT+Pz7ubJ3Xir2WKWQoK6/Y6DSeixHBGqNAOfIao0o9REBIpA5AiSyzCFng0SACNQaARJZrRGlPiJABDJHgESWOeRskAgQgVojQCKrNaLURwSIQOYIkMgyh5wNEgEiUGsESGS1RpT6iAARyBwBElnmkLNBIkAEao0AiazWiFIfESACmSNAIssccjZIBIhArREgkdUaUeojAkQgcwRIZJlDzgaJABGoNQIkslojSn1EgAhkjgCJLHPI2SARIAK1RoBEVmtEqY8IEIHMESCRZQ45GyQCRKDWCJDIao0o9REBIpA5AiSyzCFng0SACNQaARJZrRGlPiJABDJHgESWOeRskAgQgVojQCKrNaLURwSIQOYIkMgyh5wNEgEiUGsESGS1RpT6iAARyBwBElnmkLNBIkAEao0AiazWiFIfESACmSNAIssccjZIBIhArREgkdUaUeojAkQgcwRaZ9XioEGDzJAhQ7Jqju0QASJQZwhMnTo1WI+CE1mnTp3M2LFjzbRp04LdBBUTASKQHwTACbWWVpFIrZX6+mbPnm3GjRtncKQQASIwfyPQrl0707lz55qDEJzIat5jKiQCRIAIxBDgZH8MEF4SASKQPwRIZPl7ZuwxESACMQRIZDFAeEkEiED+ECCR5e+ZscdEgAjEECCRxQDhJREgAvlDgESWv2fGHhMBIhBDgEQWA4SXRIAI5A8BEln+nhl7TASIQAwBElkMEF4SASKQPwRIZPl7ZuwxESACMQRIZDFAeEkEiED+ECCR5e+ZscdEgAjEECCRxQDhJREgAvlDgESWv2fGHhMBIhBDIHhgxREjRpihQ4cyHlkMeF4SgfkRAcQjGz58uGnbtm1tbx+BFUNKY2MjAjfyjxjwM8DPgP0MjBw5suaUE9wimzNnjmVexOvv0aNHbVmY2ogAEcgNAgMHDjQTJ040c+fOrXmfgxOZ9rhLly6moaFBL3kkAkRgPkOgTZs2we6Yk/3BoKViIkAEskKARJYV0myHCBCBYAiQyIJBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSGQWTyyrG6I7WSDgIT4NPhbYIGmfRf+8ssv5ttvvzUhY1TVGgkECf3hhx9sv2fNmmU++eQTs8Yaa5g111yz1k0V6HvrrbfMYostZtq3b1+QzotfEWjap/DX+i3+bPr06aZbt27myCOPtC9utTd8++232/r/+te/bNUrrrjCrLLKKmbppZe2L/Gyyy5r45cvt9xyZoUVVjArrriiWWmllczKK69s1lprLSNhgYuaBIHce++95ne/+51Ze+21bdl9993XphUVLpGAvvTt29fW3W677cyAAQPM6NGjK4rc+cYbb1gsll9+ebPMMsuYXr16mQ8++KBEK8VJ7777rjnllFPsi7/ooosa3DvuGe3PmDHDVRg3bpzp2bOn+fe//+3S4iefffaZ2WOPPcyoUaNc1ueff2423XRTiy36BpJEG8AW/VV8gS2eAfr+zTffuPpjxowxJ598sgGW3bt3N+uvv757VgsttJBp3bq1WWqppWxa165dzU477WSf0dFHH+104KQ5+BYokgvgveGGG9q+gDwpCQjUPHh2TKGEt7Zxuu++++5YTj4u77jjDhdr/p577qmq0/LBi+SFsvV32WUXW1deDqdPHknZc3npCtq8//77ow022CCxHtr5+OOPC+r4FxdffHFiXfRtwoQJfvGC8yuvvDJaZJFFiuoLWUSvvvpqQdn4xUMPPRQJeRfVVQzkRymimTNn2mq4B6Tvt99+cTX2evbs2ZF+rvbaay9XRn7oJlG/thM/Xnfddba+/CBG1XVVlxCx60Nz8HVKvJPf/OY3rl/yReDl5O9Un1kILoCVEVRCdj5ox/9f+bBhw9wH6be//W1VTYr15eruvvvutq5YQC5NX4SkowzbogsvvNC1+dJLL0WtWrUqqg9y8dM32mij6Ouvv3b19OSf//xnQV2QLIjSb18sj+jJJ5/UKu4Yf9HRN7+eDLGiL7/80pX3T6666qpowQUXLCjv19Xzm266yVZbb731bNktt9zSV+POjzvuOKcL5KXy+OOPu3TVmXYUazb68MMPbfWzzjqrZF0fV5yLJWf/cL/o37nnnhuJJWh1NAdfvQf/iC8VbV+sMj8rl+chuYBEVuYj8eijj7oPuAxVIpknKVPj1+xNNtnE1T377LNtBiwIfbnOP//8SH6MIRo/fnz0xBNPRP/4xz+im2++Ofrzn/8cyZA0mjp16q/K5Oyiiy5ydRdeeOEIOvEiyo85WOLCN50SRr9+/Qrq4mLrrbd29Q899NDoxx9/tHVleBbJ8MvlydCqoC4IVOZoXP7pp59u25MhZXTIIYe49BNOOKGgHi5uueUWl4/7hvUmP0QTwbpFXv/+/SNYY8gDEUHw0uJ69dVXt9f+P59w+vTp42dZHBVbmbeKnn32WWsp4vjAAw9EsK6vueYa+wey/umnnwrqyzRC9PLLL0dTpkyJZKgb/fzzz/aLRHX+5S9/KSgfv2gqvnE9eu1/VqodDaiOejqSyObh08AwTT/IOIJ0KhEQjF/vmWeesdVAIEjHN+1XX31ViSpX5o9//KPTCTIoJeuss44tA9LFEExl8uTJru5qq61mX1LNwxGkKfNLtl/XX3+9y/r+++8jmWR2dUGmvuBl33zzzW0+rDmZAHfZMjEeoS3FQX58piBfC8rEvyUPvVZ9MleoSfY4ePBgp2vHHXcsIqJ33nnH5Q8aNKigblMv8MWi/X/ssccS1TQV3ySFL7zwgmt35513TiqWq/SQRMbJfvmUpolODGuZ559/Xk9Tj4888ojLx4+RbrXVVvYak88QTEBjwr8aEQvKFT/mmGPcuZ68//77BitcEBnmGSFhzbKTxnoh1prB5LUvHTp0MGJ5mWnTppmjjjrKZeHHVJEGweT6qaee6vJwAj0XXHCBTRPiNGL1uPxrr73WCKHbayE0u3CBhYy4iBVpOnfu7JK1b/pTgvK2GiEm+0PPKLTZZpvZhQ2xSl0dnCi2OO/UqRMOzRZM7qssvvjielp0xKS8SjX4ap34UaxtmwRsxEKPZ/M6hgCJLAZIqUusYKm8+OKLepp6fOqpp1z+rrvuavCBhCh5+S+IK1jmRHXghYoTwqeffmpkYtitPGL1DuSh4pOaDNk0uei46qqrFqTJUMxd68vlEv7/BKt3WFmD3HrrrfYIElKCQ4LMNVrytpll/ilByTyfdXXYf//9DVZ7Idtss42RIahdPYyrUWyR3hR84/pwLfOPLlkJ1iV4J03F11PhTmUobPSLUIbuRuYMXR5PSiNAIiuNS0EqXBRUYLVUIj6RwZJRUavqo48+MjK0tMl4YWFNwaJJE32R4LoAgS+WDHeMzE3Z5XkZ9tr0HXbYwTz44IP2XP/5Fo+6gmhe0hFuEKoTFuUWW2yRVNS6cyBz0qRJRuaZDFwt1F0ApAqyq1SUyGTYajp27OhcUGSIZe8XrhWlRLFF3uuvv26LAFP4e/nuHaXqJqVpX5Cf5jPXFHyT2pR5QJuF533OOeckFWO6hwCJzAMj6dS3yGQuxMgkcVJRm46hmMw52XN8+OETpQInUAh0YMiJFwUvJhwr4fcEyypJlMhAfJA//OEPRlwVzP/+7/860oClhm9z+KP5gnsAKUBkdc00NjYaWXGzflggHQzf4qJWAdL9e4iXw3Xv3r1dskykOyJB4u9//3uXV8mJTx7ikmGr4MsE/U4b3im2qCBuENaagi74jAGXE088sZLmC8r4uPj9KigkF03BN64D1/Dnwx/kiCOOcM/MJvBfIgIkskRofs0Qvy1LNkiBFaTf9r+WKDzz59Fkib5gSOU7YOKn430rTCbW3XxUocb/XunQEn347rvvzBdffFFUDEQIB15xZTCwaFTwEt54442OCPCyyIKBdQqFZzqGm3jR1QJDPZ1vwzmsoTTBHBvIGCJuAwUYAYNqRAnbrwNn1HLiY4uy/v3jWlYjcahKfB1LLrlkYt2m4FtKmVpjsLr1vFQ5phUiQCIrxKPkFayqhoYGl4fhU5r4ZBAfUvlWg/h7GXEhMOL4aY8gHwzDksS3BGGVYTL9hhtuMOLGYWQ10WA+BX2F1Qiv/4033rjAwpOVPiOrp7YcrBSfHGBFXn755XYi/U9/+pPtwttvv+26Ak/2coJdBhDMF/lDOSW4cvU1X4fOeo3jmDFj7DNI20XgYwsrd88993T4yoqvm2fz9ZY794kszSKDnmrxjbctTsMG82MQLOaIW0q8CK+TEAi9fhtyyTV033398D8SDO2fbLNxWWIZRfAvkpfIpe22226urFg+Lh0ncBuAnu233976cBVklrk49thjnd4333yzZGks28PRU/t64IEHliyHRPjEvffee5HMmVkveiE2Ww9HuI+o64Rs70nU4WforoV99tknkuGu6wN8s6oReYld3UsuuSSSVVR3LcPxSF1Z4jqffvppVw5+ebUQ+PMplnCxqEbK4evrgi+g+h3CZ893Y/HL5fk8JBfQIpNPaSXiD61eeeUVVwUrhfj2xMqailoy2OgrTpKabI9qNWD4J75kBXnlLvzJbH81za+HCXlYaSriJOtcIDRNj7DeYC3BckE5nUPC0PW1114z4pNmi/qrgVo3fsRQV8jVJmOPqL+RupwFG9flT+ZjkUH82uwwGOWwnxLzguKoHK9mVzg1EdMBtRDfItO5yUr1lsPX14O9sxiSQ7B3M74q7ZfleTECJLJiTEqmYFUKLz1EiQw+Uw8//LBNwyohXji80GLl2LRtt922YPkeiUpktkCV/3wiw0JBkqBdnU/DPJy/gppUB+lwE1HBiir8tSBYUfXb1jL+EfNv6vclHul2FVXzxalUTys6+kSGaBMQrN7pkBdzidjYHb+v5mCb1DGfyOJzcEl1ktLj+Go5PCOdD8MXFDauU6pDgERWBV6wBCBwncDE8RlnnFFQG5Ed8ELDooFgziQuIDqIP98VL5N07b9UpeaRtB7mqJRUkAYyAMnCJwwkkCS+jxysMRn+2qLQBYstSaAfq4QQWGK6goeVUcjYsWPNfffdZ88r+ecTGSwwFfHsN6eddpq9RJsgTH8+UrFFgabgq+34Rx/zNIusKfhqO3//+9/d4giirMR9+bQcjykIhB5zhxwXh+57XD/2JAqU9k/nj3AtL65L13wcsccvLtg/iDwJIRPPKnt9wAEHuHbEvSOxPDaaaz8w3yUk4q7Fx6xoaw8UYU5GN5DLpLbbwiSLHLauhMCJhMCL2pRVV3sv2t5dd93lymDvqKbLy5m4vUuIPxIiiC699FI7b+jPS8mChtOnJ7KQ4fTiOWjUDH+D/3/+8x8t3qzjZZdd5tq67bbbSurCXlS9z2rxBX7YF4r6wB1zky1VQnJB+TVtQZjyXwRgYcH0x7e9br3BKiMsDgwb4JyqgvkR9XbXNBzVkkKsLfhFYYgINwr8wfrAEd/8aAcuEfCf0vkefwvO0KFDrYUVd1WQMD8FTpSywdvOgUEXVvzgdoEtNIiThj5CZOO69VmC4ygElo7qvfrqqw1WVxH/C0NNWA/ygbTlhEztliXM70Awn+XPFe6999425hmsV1ixuBdYhVilVVcG3O/BBx9ssGIHwSqub5EhPy4Sesf2B7HI8Bxk/6qRTeEOW5SHZSwLHXZIrLjqERYzcF933XWNLMyYJZZYIt6Eu/bnMZOGllgdbiq+2PEge0Rte4cffjiDJzrkqzwJzf4hWTh030vp11hZArP9FkXECYgQk/tWRh5C6ZQShH7RupUesWoH8aNfoC6sHPnw2xVCWGEIFeTrHDhwoOsCVvSEPFy+zPnZyBOI2CDzaS4dVhkiP/iCOGRCeq4MQtnoCpu2B2tC/Of8avZcFj4icc51dVEeViI2hsN6ka1ELg/lsNInc18uTRYginQiQYaWkRCrKydboyLEPNP+VHqUhYwoaQUY7fjWISzGJGkKvjLv6DbkAz+sILdkCckF8OgOKiE7H7TjCcplRdC9LHiRsGyucthhh7k8sZg0ueAocyCuTKUvG0gD8txzz1VUFyF5EAMsLnBb8IfE8fbhtoE2SglcNHzS8euK9RYhFleSyNxbAYn6df1zcdC1KsTh2N2nH7Qwrh/RLrRPGN6LL5yr5+tNOweJp4XIQcBIrY+wQ2lSLb4I6qi6EZCxpUtILiCRVfnpQVgbWb208blkL2JBbVgy8KWSoVGEWF2lRFY3nQUkQxqrC9aJbAGKxA3Czjch1A9eYMQlg3UiE85OFYIPIsAjgg/K8NO9CDJktfHGzjzzzEiGY658/AT+brJIEcl2JVsXPmIgAVgbMmSOFy+4BsHAL03bRf8RMwsx28oJLLODDjrIEY++wLD0YKXG55+AhewWiECCaYK2YZlqvDfZVG7vCwSFeb0uXbpEeIGgT4a6EeYZEQMNGGA+T1Zk09TbPERphcWEOGXlpBp80Q+Ec8KXGyzRli4hiawVwJMPVTCRyWI7h4RVL8yNtARBiByskJXyvAacWFFL2xOIfPEbTu0AAA2KSURBVAj8zJorWFHESiTm3nReq1KdcFfQuapK66Ac2sTcFFbX5AWvpqqti72dwA9tw1+qVpEq0BG4Muh96RxgVR1MKKw6E7JLJperg+1peHb+nGBJRS0kMSQXcLK/CR8SbO7GXynB5HAaiaFOLQhM24a/WFOJoCkkhnbRpvrUaT8qPaKuHymi0nqVlgN5VeLAW6k+LdcUrMrVwRfP/EJiimOoI/3IQiFLvUSACGSGAIksM6jZEBEgAqEQIJGFQpZ6iQARyAwBEllmULMhIkAEQiFAIguFLPUSASKQGQIkssygZkNEgAiEQoBEFgpZ6k1FQCOEpBZiJhGoEAESWYVA1VMxbNaWqLR2UzQ2aiN0jv5OJnyXxKPdhszWn3LDT6khtDX8q+D/hs3n2DSNOiiLHyqBYyp+wxNBEUeOHOluF7HI8JuS2PAN/y/8XiRCWssOBiN7O43s8XTx11ylhBM40mLDN4JNwpEWm7ZxH0mCDfCV/OITHEtxj9h8jlDeSYKN7/jBFWzyBhbAAOHBJapuUhWm5wWB0NsiQm5LCN33etSPLUvYLiOfr7J/2P4iscnstqlKymsZbBxXEaIs2w72O0qQSa1S8oh9kPoL4tqOHhGWJy4IjYP+o0zar4YLOUUSSNL1UXZbxFXZa2xF0hBK2q5/xFYr2XFQsi4Ta4NASC6gRSaf5jwJQsn4wf6079guhJBCGiYI6fC+h5Xlh//R8klHeMbjhzpUYP1BJGKF/Vk3RC9FaGxYZtjFAEGfYA0hxE8pwZYsieNv/MCN/vYhhNyRCBsFVRFmSF4fm4YfRYElFReE1sYvNOkPdiB/+vTpNhySXxaBJhGCyf/hEnjUwxpVgeWHMEUI8U3JIQK14dpkLSFZOLnVlpuDIITyYkcyJIoQLUJ+dTuS+GXuhhGWRz6G9k9CTNt0WBuaJr+4FEn8MRvkED/QgeCHKIcN6ghZI8TldOEEm65RFz+WEhdYMLCWEAoHZYQwIyGSeDG7UVvbRxBBhDzCBnVE1JDhna0rQ+KCuqWsNyE8p1t+OzOSYbK7L9WPo/yMnSuHE99iQ2QQBJrUjfgIvyO/c+D0SAy5spvnC5TzomIEQnIBo19U/Bjqv6AfFgYvpEZUQDQNvOAYqkks/qpuRObGbF0JHJlYD8SEaBNoIx6OBuGElGRk/s2G2vEVSVBGl3/88ce7LBCO1tMj2gBxIkYZYpppulh3NhqJXvv3iF9w0nRE+hCLy7WhJyA1+cEPVy5+D1qOx+YhQCJrHn7zRW3EzcLPiOGlxYuNn4VTkV8kt+mV/qyb1sNRgzUi9lqaIJAk2sZPwamASGV46wgiHvZIy6nFBPLSUEI6P4ZQQRLlNkKYIiUk/4gAkbAwJbKKzUc5X/yf0CsXT0xDALVv3z5CCGpKbREISWScI5O3Iu+C1UCEe9bwQEJcBj8Lp6LRIJoSJUPnwbDilyRof9asWTZb+4AL/LKUzrEhpLQMF0uq0J+hgw6sVCIUj7xCtizm+S644AIbCjsecURii9l5N4QC1x8GwQqsCnTovB3K9O3bV7NKHvFLTRD8WLH/a/ElCzOxrhAgkdXV42haZ/CL4zKEspXhPoF4/r7oT7khbj5+5g2CFx+uFXBdSBOQCiSNyOD6oL9hIN+6Th36peIvIGiaHvEbAXCFgPz1r3+1vyWgixb6y0iIZQU3CfyCOggJJDl8+HAXBkd/bcn/PchPP/3U3a8Eo3SLE9pu/IhfjdIQS/rbpPEyvK5PBBiPrD6fS8W9wg+G6G8iYiVQYtcXxUNDgD8IfjQFhIGYYEpgiJ2GQIc+AfiNq2WEAID401hrsLxkocHgx0n0x3JhMUkUWFsdVhryISAHn+BsovcPK6L4oRL0fcyYMdYigz8cCFj7juLwX/N/fNhTYRDsEuJbZP4qJfzgygnIs2vXrtbKI5GVQ6u+8mmR1dfzqLo3J510krM6TjjhBIMf542L/+s/sLCUxFAO5IShVJKoRYZ8uFxgyAoHXJAWyEdJDOQICwlDQYhv7YFE1MKymSX+weKCwFLErwppUEK/77ZAwj8dWvouFT6R+QSXoMImyyqtPZLI0lCqvzxaZPX3TCruEbzY8WvnEInh736JO67At2rw024oiy1CsITgXwX/syRRiwz5GKrhTwUWIHzK5NeQTO/eve1PommeTwSwcsoJrC0V+H0pkcGKBPGWC+OtQ2bVgSN+Uk/Fvw9NK3XU0N1p5F6qHtPmLQIksnmLf5Nbh6WESX0IrCHMLSVZPUpkmAPC0E0n8Ctp3LfIYIFhLkzn4zAcxWR6qd+F9IkAFlw5gSOrChYnlMiQhv6nOfWC6HQe0Lc28VuTKtBfCaHqooXO2Wl9HusbAQ4t6/v5JPYO3vBKKFj1S1oRhAIlsm7dulVFYqgLqwsCK04cSc2ECROMONVaPbCc8KOypaydddZZx9bDP101dQklTsaPH29T0R6GsD6RlRte+taY9hfKfCLDUDcusBqx8glyV1FCLfXDMlqGx/pDgERWf8+kbI9mzpxpBg8ebMthI3ep7Tu+EiUyP63Scx3SwepTkZ+cM5dccom9HDFihMHcXFywMVvrTJ48OZ5dcI2FA0z0Q2A1gvi0LtLK9V/nx1BW+4tzWHHYugUBCcdFfsPT4Ne98Cvx+NV3ELJuUUpbnIjr4fW8R4BENu+fQdU9gAWmQyCsGiYNKVWxujBgvqlawTwaBKujvqAPiIoBke1NRS4fWN3UuTdE0yi1P1T1IQKG6u/Xr59N9smpXL99i0z7q7rlR5PtKRYl8AXgy7777msXJ9A3WGby+5KWNKEDfm+U/CBAIsvPs7I9xQbpv/3tb/YcYXR22WWXsneg81xKfmUreAWUGFDXn39CEVhl6AMEVlrcNUK2+tg8WGTnnXeePY//k72Oti7SMYcFx16IT2Q6AW8zSvzzy2p/tdgRRxxhT7G4oVas5sHygyWGFU3MsQ0bNsxm7b///ok/96d1eawvBDjZX1/Po2xvlBxQsE+fPq48XkSdS1JfMc1Ui032RNoXF/nya+T2D46kOAcZYJUP80pwl4AnPESHahh2YcVStu+oWjt/BpcLuHxMmjTJyHYgI9ug7AomCjU0NNg+3nnnndZig0UE8sMOA5AiIk5gjg0uIBDk6RyX3gvS0yb6kZ9GZBh6NzY2GtlkbokWMdD8oTDmDUFmsj3J+q9Bn+KFc0pOEJAPaFAJub8qaMfrUDkiX+h+Svl42f2H2D8Zj08m80uRzFFF4v1u70JC3WC/T1V/Rx11lK0r4XlcPdluVBIVxPpCDDO0IWQYyeS5KydDxkgsLadDLCYbbULI1KWhHiJ0+IK9nUhHeRla+llF5+KG4nSJX11RPiJydOjQwZbBHk6xuCKZ27P9lKF5wX5QxemUU04p0sOE5iEQkgswwRlUQnY+aMfrULlYXQVEpi9d0hGboCEy9+Ne9KSy8fRNNtnE1h0wYICtC4LCJvAkwSZ1JVmE8/GDFIp1FYnrRmIfxA8tEqusQLXsELDlxTIsSC91MWPGDKf7f/7nf0oViWR4G4H04/fpX4svXNS/f39XBiRHqR0CIbmARFa755SJJglAGIn3unvZ9EVElAhER5WhU4SYXwjjM2rUKNsnWGaw0lAW5cT73kZr7dmzZyQOrVGvXr0ihPoBaSEuGaLQarwuRKxAecQxKyejR492McKuv/76guIgQegWx1fXd3HpiGBByWJEQVlcSNDEqHv37pGE6y7KK5UA3bA8p0yZUirbpiFCCCw/jawBPICLDC8j2S8ayVyijXqh8dsQWYNSOwRCElkrdFMeaDDBPMnYsWPtMreEWgnWzvymGPNNmNvCViH86VxWEg4alUI3RSeVa266WEd2czcWAXwXCl8v9kViXkxdI/y8LM4xLyjBF21TmAuMY4LFEUS/6Nix4zzrYxY4ZN1GSC7gZH/WT7NG7WFSHX+VSvxlrbReteWwAohoFmmi5JtWJmQeFjsQIjtJsOBQas9qUnmmz3sEFpj3XWAPiAARIALNQ4BE1jz8WJsIEIE6QIBEVgcPgV0gAkSgeQiQyJqHH2sTASJQBwiQyOrgIbALRIAINA8BElnz8GNtIkAE6gABElkdPAR2gQgQgeYhQCJrHn6sTQSIQB0gQCKrg4fALhABItA8BEhkzcOPtYkAEagDBEhkdfAQ2AUiQASahwCJrHn4sTYRIAJ1gEBmm8YR333IkCF1cMvsAhEgAvMCAQnMGazZ4ESGn/ZCGB//dw6D3Q0VEwEiUPcIgBNqLcHjkSE2uwTnK/rhilrfCPURASJQ/wjg90LxOwq1luBEVusOUx8RIAJEII4AJ/vjiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyhwCJLHePjB0mAkQgjgCJLI4Ir4kAEcgdAiSy3D0ydpgIEIE4AiSyOCK8JgJEIHcIkMhy98jYYSJABOIIkMjiiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyhwCJLHePjB0mAkQgjgCJLI4Ir4kAEcgdAiSy3D0ydpgIEIE4AiSyOCK8JgJEIHcIkMhy98jYYSJABOIIkMjiiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyh8D/Ad78u6wI2RqRAAAAAElFTkSuQmCC",
+       "height": "400",
+       "layout": "IPY_MODEL_2f14a422c0994204a7cec7288bf01530",
+       "width": "300"
+      }
+     },
+     "203dc5460fa848fbac72ab9f6e360265": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "210dba05e900429b98252395f6b56757": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ControllerModel",
+      "state": {
+       "layout": "IPY_MODEL_0071b727b14d42178ee5f8847e94f406"
+      }
+     },
+     "229415b2fc2f4780bb01f7d782d46bd5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "BoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_bec846a60fe24aa7b6f0fc84d8c8e5df",
+        "IPY_MODEL_5fff17adac4e4dc0a3372bca5e8bdd9a",
+        "IPY_MODEL_6856509064f74a0592015f0b994936e1",
+        "IPY_MODEL_5c2a82733b2c4697a339b8e70c1cf0d7"
+       ],
+       "layout": "IPY_MODEL_c33187b97fc3496484ebe966f9929565"
+      }
+     },
+     "23b7ba07c5354d25b8320598571cdb64": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatSliderModel",
+      "state": {
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_7a0ff3db8f0a4a1db837e22419c23825",
+       "max": 10,
+       "orientation": "vertical",
+       "readout_format": ".1f",
+       "step": 0.1,
+       "style": "IPY_MODEL_c1d9753dd2a24a40ac58ac972e441a76",
+       "value": 7.5
+      }
+     },
+     "24941017437a46a0a916cf0c7dad1d17": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "26c764f3ad73430e9b3f58db1a05cb1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_dafc1188aeb64df8a2f3a00b44420bf6",
+        "IPY_MODEL_3ba892f2e4064e03ae6372130509aa77"
+       ],
+       "layout": "IPY_MODEL_ef614689b281448290284f942b096597"
+      }
+     },
+     "272a163713504232bf3ecfeb4817a992": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "273c09b617a14151965da6956ef444fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "28f8e8e2255a4829b11726a3ba22a2b4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "29d790d9b5c14890b5a1f4fd83d9ecfa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2aad977191b44fb9a25a736cc5829f75": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2bc4900e6dfd45d48e4eac9c218103b5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2d64b1144b3a4101bcbfd785777125bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2df59c4897374497959a4254e380223d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextareaModel",
+      "state": {
+       "description": "String:",
+       "layout": "IPY_MODEL_aa0795c526bb4960a2cf4533ebc6f811",
+       "placeholder": "Type something",
+       "style": "IPY_MODEL_8ec3608759db4e51b353aae740a546fe",
+       "value": "Hello World"
+      }
+     },
+     "2f14a422c0994204a7cec7288bf01530": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "314095892d6a4d409c628b0d3760efd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3226484b62eb47d1b5de58631885dcd3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3473e172c4d749b4b057c3ffe5101d82": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "354ebe7264014f0f98c3d60e30e15131": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "36c7ab780b3b4ff480a7182dcfc77122": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3af576e98b2849b8b0297dae003fd8e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P1",
+       "layout": "IPY_MODEL_29d790d9b5c14890b5a1f4fd83d9ecfa",
+       "style": "IPY_MODEL_570f9c4520004a5da8a5312c242dd64a"
+      }
+     },
+     "3b253205a4e544a39798e8f4108b4feb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3ba892f2e4064e03ae6372130509aa77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_efb3879e242e418cb35d4d87aea6a28a",
+       "style": "IPY_MODEL_6e609174592e4f5181ffe0dcddd38430",
+       "value": "3"
+      }
+     },
+     "3faa684a2f1547abb3fac50d6854f4a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3ff4730fe5be428e85ccd9c6b77fff76": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4017dc27575b41638ba6c2e4f41b1992": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4301e3b430c54e428aa5826368515bb1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "432045a32ab640459b97e44ebee05e53": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "436bf55470ae44459c5822143804e091": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatSliderModel",
+      "state": {
+       "layout": "IPY_MODEL_c14c0e98885d49058ef7c5b6c205bfd8",
+       "step": 0.1,
+       "style": "IPY_MODEL_7f6e53c41d584e388abea17400b3a8b2"
+      }
+     },
+     "44719c6e0fd0470eb3cce09370e9c0a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatRangeSliderModel",
+      "state": {
+       "_model_name": "FloatRangeSliderModel",
+       "_view_name": "FloatRangeSliderView",
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_927121ff22a64ad9bb23ff7bea7d62fa",
+       "max": 10,
+       "readout_format": ".1f",
+       "step": 0.1,
+       "style": "IPY_MODEL_3faa684a2f1547abb3fac50d6854f4a0",
+       "value": [
+        5,
+        7.5
+       ]
+      }
+     },
+     "44f766c5b641462fa7bc8d7178b264bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "450070ff643945ee8fd644ded1549bcb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_2aad977191b44fb9a25a736cc5829f75",
+       "style": "IPY_MODEL_e70aeb9915304a7ba19d32a6bf4081dd"
+      }
+     },
+     "4521a95812714511badf8e793fb3ac85": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "466d571f5f6f49018a6f721d561d930e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P2",
+       "layout": "IPY_MODEL_a3cf220852f54253b50f9aa4f43b881c",
+       "style": "IPY_MODEL_ccdd062c507644a38eafe7cb736b8ab2"
+      }
+     },
+     "474e4887b3804400b2e8b16f81dab607": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4845e579fad649d986d2474d8252a825": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "48aca8ec846a47dcb8199144d58d6b7e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4981d257664c4fe79473f1a7a999d6cd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4aa67660f43e4c9f8c0fcd4ed80715a3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4b74335d718043468ce07b99fca1f129": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SelectionSliderModel",
+      "state": {
+       "_options_labels": [
+        "scrambled",
+        "sunny side up",
+        "poached",
+        "over easy"
+       ],
+       "continuous_update": false,
+       "description": "I like my eggs ...",
+       "index": 1,
+       "layout": "IPY_MODEL_4017dc27575b41638ba6c2e4f41b1992",
+       "style": "IPY_MODEL_180d46cb59854bacb0451fa48e0a746f"
+      }
+     },
+     "5066b3bbdccd4009843bf1031950f12d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "50b43cd6edc5402bae52200aa764e244": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "String:",
+       "layout": "IPY_MODEL_3b253205a4e544a39798e8f4108b4feb",
+       "placeholder": "Type something",
+       "style": "IPY_MODEL_9bc8e4794a4a4847a50a44fd190345d3",
+       "value": "Hello World"
+      }
+     },
+     "55929ff04cb94746ac894227585a6bab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "RadioButtonsModel",
+      "state": {
+       "_options_labels": [
+        "pepperoni",
+        "pineapple",
+        "anchovies"
+       ],
+       "description": "Pizza topping:",
+       "index": 0,
+       "layout": "IPY_MODEL_2d64b1144b3a4101bcbfd785777125bd",
+       "style": "IPY_MODEL_b09b1f4f57b1405bacd1794bb77da414"
+      }
+     },
+     "570f9c4520004a5da8a5312c242dd64a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "58484636dd7f4de98346650d16f4a0cb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "594ed8bc40394b0192d63aadb7fae85b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Any:",
+       "layout": "IPY_MODEL_d53566b6791b4068adfbb05dfc37542b",
+       "step": 1,
+       "style": "IPY_MODEL_272a163713504232bf3ecfeb4817a992",
+       "value": 7
+      }
+     },
+     "5b63e849ede84a6c9ed4a64d6ea76500": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b884d1012194e1fa919d4fdd67b4f7f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntRangeSliderModel",
+      "state": {
+       "_model_name": "IntRangeSliderModel",
+       "_view_name": "IntRangeSliderView",
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_8473b767f44b4a96a4b3e3893d45c9a5",
+       "max": 10,
+       "style": "IPY_MODEL_967e3e5fd2fa487f9973fd4e23ae1cde",
+       "value": [
+        5,
+        7
+       ]
+      }
+     },
+     "5c2a82733b2c4697a339b8e70c1cf0d7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_cf5dc248c6314cc19690781fd6d174d0",
+       "style": "IPY_MODEL_946a5c251c464a96ab85d98485fde727",
+       "value": "3"
+      }
+     },
+     "5ccd25d357664504a695465878eb3b10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TabModel",
+      "state": {
+       "_titles": {
+        "0": "An accordion",
+        "1": "Copy of the accordion"
+       },
+       "children": [
+        "IPY_MODEL_8d91a77bfcc349d5904c4118704dd9a4",
+        "IPY_MODEL_8d91a77bfcc349d5904c4118704dd9a4"
+       ],
+       "layout": "IPY_MODEL_11eb8e2d33354913bb0b3ae8a8360a62"
+      }
+     },
+     "5fff17adac4e4dc0a3372bca5e8bdd9a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_6c38a277b66b4b139dfe8339dc6b9953",
+       "style": "IPY_MODEL_95b918719f6144c8af2ef0122c514e84",
+       "value": "1"
+      }
+     },
+     "6065a18df0d64652a5f44745994d3b2c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7c03cae23eea478e9afd4b279d1de230",
+        "IPY_MODEL_6706c2c576024590a28077f3f0e2e5fa",
+        "IPY_MODEL_86ac365801704183b149221c4c69ba93",
+        "IPY_MODEL_19f7f65a07cf4edca7a3b85e920ca4b6"
+       ],
+       "layout": "IPY_MODEL_58484636dd7f4de98346650d16f4a0cb"
+      }
+     },
+     "6403c6cd5c8b498ca96780d1a54bd59d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "65eeefb571a84aa58c97ccef0b7ee430": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6706c2c576024590a28077f3f0e2e5fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_ea8e003b943748fdb46f53be79c9be91",
+       "style": "IPY_MODEL_8eca1e95897c4648b916d74219c6e1b1",
+       "value": "1"
+      }
+     },
+     "681badd202664c2ebb5247ab3c12ac2b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6856509064f74a0592015f0b994936e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_926f9ad5929d40ef9b12b65aeeec3e18",
+       "style": "IPY_MODEL_6e09c9e376ca498b9365203c77c5e113",
+       "value": "2"
+      }
+     },
+     "68835d2dbce74484b7c8d6478c746e41": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "PlayModel",
+      "state": {
+       "description": "Press play",
+       "layout": "IPY_MODEL_7b869f4411534738bbb5658e8ba4031c",
+       "style": "IPY_MODEL_8f85f5f60ad14e599f6bfe13c8705a2f",
+       "value": 50
+      }
+     },
+     "6aab72bf708d4dc0b31f326db946e06a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6b2d67f38aed4d7094266028b2984197": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6bd826e68d6f4fa7928aebb8311422e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6c38a277b66b4b139dfe8339dc6b9953": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d1adb85bd204a5eba71f75b9eec388f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fe7f6036d45646488689fc5ae3d77963",
+        "IPY_MODEL_436bf55470ae44459c5822143804e091"
+       ],
+       "layout": "IPY_MODEL_b512427abbb9431d95b9f8af0012828b"
+      }
+     },
+     "6e09c9e376ca498b9365203c77c5e113": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6e27340506af44e8b2f1bb25a8522bda": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "description": "Click me",
+       "icon": "check",
+       "layout": "IPY_MODEL_8bd0462243194ff282a67719b0612968",
+       "style": "IPY_MODEL_80337ac481294ac08a9db3a4cbeb72e1",
+       "tooltip": "Description"
+      }
+     },
+     "6e609174592e4f5181ffe0dcddd38430": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7646344abe9541baa5cfdcc22a56655a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P3",
+       "layout": "IPY_MODEL_4981d257664c4fe79473f1a7a999d6cd",
+       "style": "IPY_MODEL_05dd075f9fdb424c95356871a054a93a"
+      }
+     },
+     "770221448e384a47aafad0ba9424afd3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ColorPickerModel",
+      "state": {
+       "description": "Pick a color",
+       "disabled": false,
+       "layout": "IPY_MODEL_4aa67660f43e4c9f8c0fcd4ed80715a3",
+       "style": "IPY_MODEL_7f98262b6ada4eac98047262c604d9aa",
+       "value": "blue"
+      }
+     },
+     "772dfdb4dc784aecb7fb1d72c4f15dfe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "79e543480ea149d6a4ceb40c8adaf0ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SelectMultipleModel",
+      "state": {
+       "_options_labels": [
+        "Apples",
+        "Oranges",
+        "Pears"
+       ],
+       "description": "Fruits",
+       "index": [
+        1
+       ],
+       "layout": "IPY_MODEL_6aab72bf708d4dc0b31f326db946e06a",
+       "rows": 5,
+       "style": "IPY_MODEL_89122390cc814ac0b182f024cc63ba04"
+      }
+     },
+     "7a0ff3db8f0a4a1db837e22419c23825": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b07b08994c0409da6a5ee7de26cc4ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b869f4411534738bbb5658e8ba4031c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7c03cae23eea478e9afd4b279d1de230": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_adea11f461854821bb0722d12a500289",
+       "style": "IPY_MODEL_4301e3b430c54e428aa5826368515bb1",
+       "value": "0"
+      }
+     },
+     "7c81902326ab41ba9dc0ab245d40747b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7ceefe6080274b3db18b7a64c8287aa0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DropdownModel",
+      "state": {
+       "_options_labels": [
+        "One",
+        "Two",
+        "Three"
+       ],
+       "description": "Number:",
+       "index": 1,
+       "layout": "IPY_MODEL_3ff4730fe5be428e85ccd9c6b77fff76",
+       "style": "IPY_MODEL_a890b9a9cab2453ba4c0629c32bc59ce"
+      }
+     },
+     "7f6e53c41d584e388abea17400b3a8b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7f98262b6ada4eac98047262c604d9aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "80337ac481294ac08a9db3a4cbeb72e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "822668978e7e457a99a6309ffbbe78d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8473b767f44b4a96a4b3e3893d45c9a5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "851561d68e084e7e9ab148b0b2335428": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8571dd1a9c77473ebd115fdb68cc1113": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b9da968bce34427783767c94e8f75bb9",
+        "IPY_MODEL_26c764f3ad73430e9b3f58db1a05cb1b"
+       ],
+       "layout": "IPY_MODEL_0003bd8881b545ad8fb141d18645c7a9"
+      }
+     },
+     "86111472ed374ea5908db6e6ac508630": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LinkModel",
+      "state": {
+       "source": [
+        "IPY_MODEL_68835d2dbce74484b7c8d6478c746e41",
+        "value"
+       ],
+       "target": [
+        "IPY_MODEL_09c2d1294b1d48ea96982a307a53f529",
+        "value"
+       ]
+      }
+     },
+     "86ac365801704183b149221c4c69ba93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_6b2d67f38aed4d7094266028b2984197",
+       "style": "IPY_MODEL_4521a95812714511badf8e793fb3ac85",
+       "value": "2"
+      }
+     },
+     "8851586a96234482b1c764d2cbdbd3c8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "88a5f5f11fe64014a4445656f79aa5ed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "89122390cc814ac0b182f024cc63ba04": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8bd0462243194ff282a67719b0612968": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8bda6084c3564f5499698c25a310d0dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8d91a77bfcc349d5904c4118704dd9a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Slider",
+        "1": "Text"
+       },
+       "children": [
+        "IPY_MODEL_f9ef62620cf6443a8ad1245e535c7c39",
+        "IPY_MODEL_450070ff643945ee8fd644ded1549bcb"
+       ],
+       "layout": "IPY_MODEL_2bc4900e6dfd45d48e4eac9c218103b5",
+       "selected_index": null
+      }
+     },
+     "8ec3608759db4e51b353aae740a546fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8eca1e95897c4648b916d74219c6e1b1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8f85f5f60ad14e599f6bfe13c8705a2f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "90da5d5271124591b7c9f293eedf4ea1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "91cc0d2a3abf4fe3b225ed614113cc92": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "922ae8e7c80b4f0f88916599d912a589": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_a5e78c7a354649f79209b7a3ef3413eb",
+       "max": 10,
+       "style": "IPY_MODEL_6bd826e68d6f4fa7928aebb8311422e4",
+       "value": 7
+      }
+     },
+     "926f9ad5929d40ef9b12b65aeeec3e18": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "927121ff22a64ad9bb23ff7bea7d62fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "946a5c251c464a96ab85d98485fde727": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "95b918719f6144c8af2ef0122c514e84": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "960df785cc2b4d129bcd9008e834f17d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "967e3e5fd2fa487f9973fd4e23ae1cde": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9bc8e4794a4a4847a50a44fd190345d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3cf220852f54253b50f9aa4f43b881c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a5e78c7a354649f79209b7a3ef3413eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a6caf10f0e7b4559abab415043731a08": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HTMLMathModel",
+      "state": {
+       "description": "Some HTML",
+       "layout": "IPY_MODEL_c30c321443f84697a8382ba9a2b30933",
+       "placeholder": "Some HTML",
+       "style": "IPY_MODEL_90da5d5271124591b7c9f293eedf4ea1",
+       "value": "Some math and <i>HTML</i>: \\(x^2\\) and $$\\frac{x+1}{x-1}$$"
+      }
+     },
+     "a70f88798dd64a0eb440ac9280460b71": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_88a5f5f11fe64014a4445656f79aa5ed",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "0 Hello world!\n1 Hello world!\n2 Hello world!\n3 Hello world!\n4 Hello world!\n5 Hello world!\n6 Hello world!\n7 Hello world!\n8 Hello world!\n9 Hello world!\n"
+        },
+        {
+         "data": {
+          "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkz\nODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2MBERISGBUYLxoaL2NCOEJjY2NjY2NjY2Nj\nY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY//AABEIAWgB4AMBIgACEQED\nEQH/xAAaAAEBAAMBAQAAAAAAAAAAAAAAAQIDBAUH/8QAMxABAQABAgMHAwQBBAIDAAAAAAECAxES\nITETFUFRUmGRBBTRIjJxgTMFI0KhscEkNGL/xAAWAQEBAQAAAAAAAAAAAAAAAAAAAQL/xAAZEQEB\nAQEBAQAAAAAAAAAAAAAAARExQSH/2gAMAwEAAhEDEQA/APn4AAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAA6+7tb1YfN/B3drerD5v4XByDfrfSamjtxXG7+Va+zvsgwGfZ3zh2WXnAYDPs\nsvOL2WXnAaxsmjlb1jd9hq+rD5oOUdXd+r6sPmr3fq+rD5oOQdfd+r6sPmnd+r6sPm/gHIOvu/V9\nWHzfwd36vqw+b+Acg6+79X1YfN/B3fq+rD5v4ByDr7v1fVh838Hd+r6sPm/gHIOvu7W9WHzfwd3a\n3qw+b+DByDs7u1vVh838Hd2t6sPm/gwcY7O7tb1YfN/B3drerD5v4XBxjs7u1vVh838Hd2t6sPm/\ngwcY7O7tb1YfN/B3drerD5v4MHGOzu3W9WHzfwd263qw+b+DBxjs7t1vVp/N/B3brerT+b+EwcY7\nO7db1YfN/B3brerT+b+FwcY7O7db1YfN/B3brerT+b+EwcY7O7db1afzfwd263q0/m/hcHGOzu3W\n9Wn838Hdut6sPm/hBxjs7t1vVp/N/B3brerT+b+FwcY7O7db1afzfwd263q0/m/hBxjs7t1vVp/N\n/B3brerT+b+AcY7O7db1afzfwd263q0/m/gHGOzu3W9WHzfwd263q0/m/gHGOzu3W9Wn838Hdut6\nsPm/gwcY7O7tb1YfN/Cd3a3qw+b+Acg6+79X1YfN/Cd36vqw+aDlHV9hq+rD5qfY6vqw+aD1VBsc\nn1/7cP5cTu+v/wAeP8uFmizoqRUBUUDHrHox52PWPRiwUFUAEABQAAUAAAURQAAAFAAFQAFRQBAF\nAAAQAFABAAAAAAAAAABEqoCIoDGsayqVBtUGhy/X/wCLH+XA9D6//DP5eezRYqRUBUAWdY9GPOnV\n6M6LBVRVABAAAAUFQBQAFQBRFAAAAAAUFQAAAAAAAAQURQAQFEUAAAAAAEFQERUoIxrKsaDcCqOb\n66f7H9vOen9b/wDXv8x5jNFipFQFQBZ1ejOjzp1ejOiwVUUAAABQVjvPOLvEFQVQAAAAVAFAUAEA\nBQAAAAAAAQAAAAAAAADfYc31mpcZwy9QXV+qmN2x5sPu8p1krk5nNB6Gl9ThqXbpW95E3llj1NPL\niwlBkAoiVUBKxrKsaC/c6Pri/c6PrjyhNHf9Tr6WehljjlvXAALFSKgAAsejOjzo9GdIsFVAFAAc\nurr3pOUbtfPg068+5b0FuW9WW+dYKg36evljed3dmGXFN3Djhxc5HXoyzHmo2KgooAAACoAoAAps\nogqbAAAAiCiAKIAogCiABugCuT6yc5k6mr6ib6fOboOPHHdldPkSWTlN04s90Vnjp8t66tKbaccn\nDlcufR2YTbHZUZbqgoAgFYrUB5/AvZ+7o7NezZHP2Xuwzx4a7OBo+ox2yn8A0qbAAKA9HH9sec9D\nH9sUZAoAANX1OPFpX2ee9SzeWPNzx2zs9wSY2zck3rbjOW3RelZaxljlw48nRo23HnebnmXs26My\n336RYVvVBWQFUAAAAVlIxjZi1A2NmQ3iMeFLizY1LBrotYsKAIAgAAAAgAKCoIKxs3m1VLeXIHJl\ntjltKlvkak2yrDx5o1rZNS3bd14ftjhlk2duOW85rErIBUEVKCIqIJsbKoJs5vqp+rH+HU5vq+uI\nOeAIAAD0cf2z+HneL0sP2T+ABRQBr1NWac59fIGfSc3Nq3TuW82atTWy1Ot2nlGpR0crGFvNrxys\nrZMctT9nOs41pK7NKbYTdo0vp8pZctpHSqKAqAACooAALGzFqlZSrBs3LZJvbtGHEmpJnp5Y3pW9\nRsllm8ssqVp+n/RpTH07xnamiVFtRlUAQAAAEABQEN0FS3ZLUtAtIJZug1a+F23ng1zT4m+y3xrD\nHlvBWrPHhykdeG0x51zWXLWxdUwnk1nxCeyym20YZXaoMxJRQABFIIDm+r/4ulzfV/8AFBzwIAAA\nPRw/ZP4ea9LT/Zj/AADIEUTLLhxtrg1M7llbXXr2TDn0aLjo5dMtqsGgZ6mnwbc5d2ugMsM8sLvj\ndmKIPQ0daauP/wCo2uD6a7a2Pu7wAAAFFEVANxFFN0AZbm7EBJeHUvllN2e7Xny4b5VmAAACAqAA\nJuAqCAu6CWoFqSnWmWUkQZeCxrwzl6VlKDLZq1f02ZNu7V9R+zeLOiaWP+5xdXTNnP8AT23Ful5r\nRb0as21oyvOw8GeN5Mt2vBkgyQFFioqA5vq+mLpc31f7cf5QcwQAABPF6On/AI8f4ed4t+P1OUxk\n2nIHYOT7rLyxPusvKKNn1X7I423U1rqTayRpqi227b+CCRAUAXDLhyl8npS7yXzeY6sPqLjhJwb7\nA6hzfc30L9zZOeH/AGDoGnHWuU34dp/K9tL0sFbVae22u1jTra/FtJvNvcR1jz+PL1ZfJ2mXqy+T\nR6A5NLX4JZlvWf3WPlQdA0fdYeVPusPKg3ZzfCwxu+MrT91h5VMPqMMZtdwdA0/c6fufc4e4Nw0/\nc6fv8H3On534BtGr7jT8/wDo+40/O/C6NitGevjwXhvNo7fU9X/SaO0cXb6nq/6Z6eveL9eXL+DR\n0pWHbafqZTLHKcqB0aNbK+Dbl0adSoLp/pjbxsccd5yZzCSc4DKb3ompjcsdry9yYc/05Mst+GzI\nDS05hh4W+cZePRNOzGTGM9lGPhzaL+6t+Uvi5pds7KXg2Ys2Eq8ePqnyDITjx9U+Tix9U+Qc/wBz\nmfcZufipxVB0fcZ3xa89XLPbfm18VXioKJzUAADznmnCXdN75gvCbJvfM3oL0YruiguMtvJG76T/\nAC8/CAk0NSzfZjlhlh+6bO65NOpOPGxNaxyV06fLCOeza7Vn2gjdvI16uX6eTC51jbQbMcrZ1ZbT\nzaZdl4qDbLOLza71TipxfwAf2nEcQi/2JxLxADLHVslnDjz9jtb12x5Csefmc9mfb3nvjjz9mMz9\noInM5su1/XxcE/jwZXX3y37PGe2wNfM5tmetMsdpp44+8a9/YDmJubgvNDc3AVN4bwFdGE3xaMcs\nZf1Y7t2neXIqxhqcWN5WsZbbzZ623i142bhW/HeftrbjnnOsla8cd+crZOQjo+lx7bWxxvJ3a3+m\ncv08fxu4vo88McrcspL4b16Wjr5ad3ltx9ruo4r9PlpY/qm8njGi3ny6PQ+v15lp247zfrHmb7gv\nPfwcuv8A5dpXRu5da7aq3hDLHbHq0b+zoyv6Gjl5srU3Xe+Ry8zeb+AiAAAAyVFBAAS9EZXoxARQ\nBF8EAZaeXBnKxQHZlqTaWXdjM45pdmUyRrWzUw4uc6tVm15s5lszx4c+qo0Dtmjp7bbObV0+DPbw\n8AxrBRF09S4byTqy2m3TdhjN8tpdmy8U5Xagx4ZxT/w2zGbbcmnPe3estO3K7b/2YsNTGTHedTHC\ncPOdWzW07hnjvvtlN+fg13lN5OS2WXKhhccN5lGGdlz3nRlZvOnNrQUnUAXwRbOSbAAAAAAAAANu\nll4NS4XbKA3as3xaI69pljs5cptlZ5C104X9MZytGnxWbtkt6CM2WH6bvjlZfapMLVy2wnuDK6up\nnyyytk80vTeNXO842YW2cuoMus3c2tN8954N+9nPZh1vRbRjlj/tuV3Xa41xXlai1ABFAAABkCgg\nAF6MVvRAAAKi1FABBAAWMpbKxig2zVy2iZ5ce0a+TLikFOBeBOOHGIxynDlyTe79Vy/Vd02BlZNu\npOkrHZd75guWV5Zb3dLnb1LveW6bAvF7G/FlN02JNqDbnpyZWY9Iz0PpM9fKzDbeTfnUuvL/AMMZ\nfaLh9VqaeXFhld1E7HK6M1OW2/C14zbLneizVswuG94bd7EmWPkDG9UVEAAAAAAAnVlcMpdrOacN\nFdWF2jHPTmeUqY58ui3K2Ctk4cOXQuWHkx085njw5dVuFnvBk7TGftlTfe72ptfJeC+NBZZPFJeG\n7ys9OYeM5s+DAE7THKc8bv7McuXO8mduOE5Rz6tuWO4Lhl+jK+7myu+VrLLO7bMBaACKAKAAyVAQ\nBQS9GLK9KxAWTfKSeKM9Gf7k9gbNTQ9NabhlN946rd2NBymzpsnjGPBj5A02bVi33DGsLjAYRTbY\nARUAAABQAARUUABFEUUQAQAAAAGeOG65TbbaA1spnw9NvhOuW15NnY4+OpP6gE1pf34ys+HTzm8a\nsphLtN7/ACxl26A2TDa/pu/stl32vw13f5XLO3bfrIou1jZhq5Y+LXx3bZZd+qDd2ty6bLMd+d3a\ndvJlNTLGbXmgvFtldmU1PNolu9rLe3xBsuUvXowuXFynRP7ZQVoy/cjPU/cwVAAFAFABGQACooJf\nFiyvRiA2aN2yat2WGW2UB0bkrC3mSis7WNLUES1jatYglRWIKIAAAG6KAbgAAAbgAqAKi+CAAAC7\nGwLxWTaFzvRjZfJAZTa3nzbduTTjdmyZcgS3G9dzaepgTbxBsmy3YmO836QuMku1Ua6TKlxsvN2f\nS/TaeppcWpLbv4UGi5eTC13Z/SaP/G5y/Li1NLLD93/ndMGMrKMF3MGyMmriq8dTFNXru1s8rxdW\nOyoguxsAAKACMgAFQQKwrOsKoW8pDxhOZOoNlpueJegLvusrXGQMqiVASopegMQAABQAQAAAAAAA\nBfBF8EAEUGRLZeXJJ0VRbnn04t2P8xdgGN9hk6fpc/pcf8+Ft8/AHJ/Q9rHV/wBN25Y4f3iZX/Tb\n4acMHmfT6mEvDqb8NnXya9XOXKzH9rs1fsJlvhcv4m//ALc1098rccbtegNPN6X0d/8Aj47uHLC4\nznLHT9PrY46fDldgdGrltjb7OHUnBpzC/u33rdrfUST9F3rlvPmDHZdlATYU2BBUBUTc3AAQAAZB\n4AAeIgMWVYqBj1RcedBsRlZtNksBiTpuJBVvQW9EgiF6FQEAAAAAAAFFRRBFBUAEXwQ8AEABZdl3\nQBdzdAF3N0AXf2N/ZAF3ZTPKTbe7fywAZcRxMQGXETJiAy4jiYgMuI4mIC8RugC7m6AKIAoigqpF\nAAAYM2ADZo475McMLnltHXjhjp47QGvKc2GTPK82GQMduTHFnby2iYzruBeiRlZyYQCsWWTEAAAF\nAAFEUERQFAAQEEW9EW9EAVFAAAAAAAAAAAAAAAAAAAAAAAGvtL7HaX2BsGvtL5Q7S+UBu8FaO1y8\nodrl5QG8ae1y8odrl5QG1j4sO1y8oY62WN32n9g79HS4MeK9aalcl+t1bOmPwx+5zvhAdFYWtPb5\neUS6uV8IDbcmWGO7n7S+zKa+Um0kBvzvhGMae1y8odtl5QG3Ji13Vt8IdpfKA2DX2l8odpfKA2DX\n2l8odpfKA2jV2l8odpfYGxWrtL5Q7S+UBtGrtL5Q7S+UBtGrtL5Q7S+UBtRr7S+x2l9gbPBGHaXy\nidpfKA2K1dpfZe0vsDYNfaX2O0vsDYNfaX2O0vsDYNfaXyh2l9gbBr7S+x2l9gbBr7S+UO0vsDYN\nfaX2TtL7A2jX2l9jtL7A2DX2l9jtL7A2DX2l9jtL7A2DX2l9jtL7A2DX2l9jtL7AwAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAB//Z\n",
+          "text/html": "\n        <iframe\n            width=\"400\"\n            height=\"300\"\n            src=\"https://www.youtube.com/embed/eWzY2nGfkXk\"\n            frameborder=\"0\"\n            allowfullscreen\n        ></iframe>\n        ",
+          "text/plain": "<IPython.lib.display.YouTubeVideo at 0x1073d1f60>"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ]
+      }
+     },
+     "a890b9a9cab2453ba4c0629c32bc59ce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aa0795c526bb4960a2cf4533ebc6f811": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ac7af961026640a59d751c614dffa0d7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "adccb79d75264db3b6941f056d9282ff": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "BoundedIntTextModel",
+      "state": {
+       "description": "Text:",
+       "layout": "IPY_MODEL_18e9b06c0d824dd697826754af6aa889",
+       "max": 10,
+       "style": "IPY_MODEL_1e8cb22616f14fbdb570d965d017aab0",
+       "value": 7
+      }
+     },
+     "adea11f461854821bb0722d12a500289": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b09b1f4f57b1405bacd1794bb77da414": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b0c31a8ea5414dc8b51c235f9651427e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b2590573c9414109bdb7e22c3da3177b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b512427abbb9431d95b9f8af0012828b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b678f4cf881543bab5dff3ec8692c0fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b8d5907b1bdf484e80bebe9416d1cfb3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b9da968bce34427783767c94e8f75bb9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cfd9ee058b4c4db2af82c175663dece5",
+        "IPY_MODEL_f33e8a20db0a472e84b997ef0ac7478a"
+       ],
+       "layout": "IPY_MODEL_91cc0d2a3abf4fe3b225ed614113cc92"
+      }
+     },
+     "bb01c4cd36c04ca5908521fd787a71c6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bdf41e039ca54d799b172276f43c9c73": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bec846a60fe24aa7b6f0fc84d8c8e5df": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_ff9b8499306e44799df6b1f3a7a7aeab",
+       "style": "IPY_MODEL_db15d51f079e44c1af4ff4b56e922f88",
+       "value": "0"
+      }
+     },
+     "c14c0e98885d49058ef7c5b6c205bfd8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c1d9753dd2a24a40ac58ac972e441a76": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c30c321443f84697a8382ba9a2b30933": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c324d0c41a624a4a999a9c8f3ba6df68": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "info",
+       "description": "Loading:",
+       "layout": "IPY_MODEL_ac7af961026640a59d751c614dffa0d7",
+       "max": 10,
+       "style": "IPY_MODEL_960df785cc2b4d129bcd9008e834f17d",
+       "value": 7.5
+      }
+     },
+     "c33187b97fc3496484ebe966f9929565": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c93c66689bfd42958f881476651072f8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ca41b26e798c44dd8e9993c988bb8e4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ToggleButtonsModel",
+      "state": {
+       "_options_labels": [
+        "Slow",
+        "Regular",
+        "Fast"
+       ],
+       "button_style": "",
+       "description": "Speed:",
+       "icons": [],
+       "index": 0,
+       "layout": "IPY_MODEL_6403c6cd5c8b498ca96780d1a54bd59d",
+       "style": "IPY_MODEL_fa272f1a5f0a4d678aab4e43b298adc3",
+       "tooltips": [
+        "Description of slow",
+        "Description of regular",
+        "Description of fast"
+       ]
+      }
+     },
+     "ccdd062c507644a38eafe7cb736b8ab2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cd17431a00f143b38bcd0fe4fe135df1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P4",
+       "layout": "IPY_MODEL_e8d014efb20f4513a4403d304c4e9168",
+       "style": "IPY_MODEL_8851586a96234482b1c764d2cbdbd3c8"
+      }
+     },
+     "cd886f33ed9348f1a36ce1b635d507a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf5dc248c6314cc19690781fd6d174d0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cfd9ee058b4c4db2af82c175663dece5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_772dfdb4dc784aecb7fb1d72c4f15dfe",
+       "style": "IPY_MODEL_8bda6084c3564f5499698c25a310d0dd",
+       "value": "0"
+      }
+     },
+     "d3590a9f39dc48da89cb648b571d26c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P0",
+       "layout": "IPY_MODEL_203dc5460fa848fbac72ab9f6e360265",
+       "style": "IPY_MODEL_ee122cdbe78540f2bc652ed0911e9da7"
+      }
+     },
+     "d4e15f831b4d4fc194c330215f2b5433": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatSliderModel",
+      "state": {
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_48aca8ec846a47dcb8199144d58d6b7e",
+       "max": 10,
+       "readout_format": ".1f",
+       "step": 0.1,
+       "style": "IPY_MODEL_cd886f33ed9348f1a36ce1b635d507a7",
+       "value": 7.5
+      }
+     },
+     "d53566b6791b4068adfbb05dfc37542b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d58522711a194316a0ce902c67c6e6fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d614b9280bcd46dab9cd5800558448d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DropdownModel",
+      "state": {
+       "_options_labels": [
+        "1",
+        "2",
+        "3"
+       ],
+       "description": "Number:",
+       "index": 1,
+       "layout": "IPY_MODEL_b2590573c9414109bdb7e22c3da3177b",
+       "style": "IPY_MODEL_5066b3bbdccd4009843bf1031950f12d"
+      }
+     },
+     "d7efea79fc884588b649229ff7d75763": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "BoundedFloatTextModel",
+      "state": {
+       "description": "Text:",
+       "layout": "IPY_MODEL_681badd202664c2ebb5247ab3c12ac2b",
+       "max": 10,
+       "style": "IPY_MODEL_3226484b62eb47d1b5de58631885dcd3",
+       "value": 7.5
+      }
+     },
+     "d8225b7fc20446968e0d95052ebac7f1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dafc1188aeb64df8a2f3a00b44420bf6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_bdf41e039ca54d799b172276f43c9c73",
+       "style": "IPY_MODEL_24941017437a46a0a916cf0c7dad1d17",
+       "value": "2"
+      }
+     },
+     "db15d51f079e44c1af4ff4b56e922f88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dbdd90a3fc044541b3ba1043f44e7769": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "FloatTextModel",
+      "state": {
+       "description": "Any:",
+       "layout": "IPY_MODEL_f68684f0be3d477488f3c3ba256e0b82",
+       "step": null,
+       "style": "IPY_MODEL_432045a32ab640459b97e44ebee05e53",
+       "value": 7.5
+      }
+     },
+     "e36f8d95340b485b916f62581d9d3de1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e4a950e1529d48cfb13726a683eb0bbd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "description": "Loading:",
+       "layout": "IPY_MODEL_c93c66689bfd42958f881476651072f8",
+       "max": 10,
+       "style": "IPY_MODEL_bb01c4cd36c04ca5908521fd787a71c6",
+       "value": 7
+      }
+     },
+     "e694c6ad7eab4ff080d9fe0084bfebfb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e70aeb9915304a7ba19d32a6bf4081dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e72a32fae9854c079a1e95685330bcbd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "SelectModel",
+      "state": {
+       "_options_labels": [
+        "Linux",
+        "Windows",
+        "OSX"
+       ],
+       "description": "OS:",
+       "index": 2,
+       "layout": "IPY_MODEL_36c7ab780b3b4ff480a7182dcfc77122",
+       "style": "IPY_MODEL_b678f4cf881543bab5dff3ec8692c0fa"
+      }
+     },
+     "e74f4a3ca1e44eea8a3bd03e34fa3a1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "CheckboxModel",
+      "state": {
+       "description": "Check me",
+       "disabled": false,
+       "layout": "IPY_MODEL_b8d5907b1bdf484e80bebe9416d1cfb3",
+       "style": "IPY_MODEL_4845e579fad649d986d2474d8252a825",
+       "value": false
+      }
+     },
+     "e8d014efb20f4513a4403d304c4e9168": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea79e8a297894150b2ed674ea5fcacf1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_68835d2dbce74484b7c8d6478c746e41",
+        "IPY_MODEL_09c2d1294b1d48ea96982a307a53f529"
+       ],
+       "layout": "IPY_MODEL_b0c31a8ea5414dc8b51c235f9651427e"
+      }
+     },
+     "ea8e003b943748fdb46f53be79c9be91": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ec884ea2ed52440eba185a2c7574bf85": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "description": "Pick a Date",
+       "disabled": false,
+       "layout": "IPY_MODEL_e36f8d95340b485b916f62581d9d3de1",
+       "style": "IPY_MODEL_1367e79137ba4276ba7b01e7a060b692"
+      }
+     },
+     "ee122cdbe78540f2bc652ed0911e9da7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ee5d579b54d147b393fcac7ad793bbbf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Click me",
+       "icon": "check",
+       "layout": "IPY_MODEL_7b07b08994c0409da6a5ee7de26cc4ca",
+       "style": "IPY_MODEL_273c09b617a14151965da6956ef444fd",
+       "tooltip": "Click me"
+      }
+     },
+     "ef614689b281448290284f942b096597": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ef674bc6a53049fdac81eefc1fe97047": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "efb3879e242e418cb35d4d87aea6a28a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2d2542a43bb483a9db9be579441d52a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f33e8a20db0a472e84b997ef0ac7478a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_003f197d4557427c834c6489193761c7",
+       "style": "IPY_MODEL_f2d2542a43bb483a9db9be579441d52a",
+       "value": "1"
+      }
+     },
+     "f5996d4edf3643178abcea86d08162b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "description": "Some HTML",
+       "layout": "IPY_MODEL_7c81902326ab41ba9dc0ab245d40747b",
+       "placeholder": "Some HTML",
+       "style": "IPY_MODEL_65eeefb571a84aa58c97ccef0b7ee430",
+       "value": "Hello <b>World</b>"
+      }
+     },
+     "f68684f0be3d477488f3c3ba256e0b82": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f9ef62620cf6443a8ad1245e535c7c39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "layout": "IPY_MODEL_851561d68e084e7e9ab148b0b2335428",
+       "style": "IPY_MODEL_3473e172c4d749b4b057c3ffe5101d82"
+      }
+     },
+     "fa272f1a5f0a4d678aab4e43b298adc3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ToggleButtonsStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "button_width": ""
+      }
+     },
+     "fc995a82740e4c70b069b9784a04a5ce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "ValidModel",
+      "state": {
+       "description": "Valid!",
+       "layout": "IPY_MODEL_822668978e7e457a99a6309ffbbe78d9",
+       "style": "IPY_MODEL_e694c6ad7eab4ff080d9fe0084bfebfb"
+      }
+     },
+     "fe7f6036d45646488689fc5ae3d77963": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.0.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_28f8e8e2255a4829b11726a3ba22a2b4",
+       "style": "IPY_MODEL_354ebe7264014f0f98c3d60e30e15131",
+       "value": "The $m$ in $E=mc^2$:"
+      }
+     },
+     "ff9b8499306e44799df6b1f3a7a7aeab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/reference/widget_org.py
+++ b/reference/widget_org.py
@@ -1,0 +1,245 @@
+import string
+import inspect
+from collections import defaultdict
+
+import ipywidgets as widgets
+from IPython.display import HTML
+
+
+def extract_module_name(obj, full=False):
+    """
+    Get the name of a module for an object.
+    """
+    properties = inspect.getmembers(obj)
+    for name, value in properties:
+        if name == '__module__':
+            if full:
+                return value.split('.')[-1]
+            else:
+                return value
+    else:
+        raise ValueError('How odd...no moduel was found!')
+
+
+def organized_widgets(organize_by='ui'):
+    """
+    Return a dictionary of all DOM widgets organized by either which module
+    they are in or by the type of UI.
+
+    Parameters
+    ----------
+
+    organize_by : str, optional
+        Must be one of 'ui' or 'module'. Determines the keys in the returned
+        dictionary.
+
+    Returns
+    -------
+
+    dict
+        Dictionary whose keys are the names of the widget groups and whose
+        values are dictionaries. The dictionaries which are the values of
+        ``groups`` have the name of the widget to be displayed as
+        the key and the class of the widget as the value.
+    """
+    valid_organizations = ['ui', 'module']
+    if organize_by not in valid_organizations:
+        raise ValueError(f'Invalid value {organize_by} for organize_by. '
+                          'Valid options are: {valid_organizations}')
+
+    all_wids = inspect.getmembers(widgets)
+ 
+    widget_dict = {name: wid for name, wid in all_wids
+                   if not name.startswith('_') and
+                      name[0] in string.ascii_uppercase and
+                      issubclass(wid, widgets.DOMWidget) and
+                      name != 'DOMWidget'
+                  }
+
+    if organize_by == 'ui':
+        containers = ['Box', 'VBox', 'HBox', 'GridBox',
+                      'Accordion', 'Tab', 'AppLayout', 'GridspecLayout',
+                      'TwoByTwoLayout', 'Stacked']
+        groups = dict(
+            sliders={k: v for k, v in widget_dict.items() if 'Slider' in k},
+            buttons={k: v for k, v in widget_dict.items() if 'Button' in k},
+            containers={k: v for k, v in widget_dict.items() if k in containers},
+            texts={k: v for k, v in widget_dict.items() if 'text' in k or 'Text' in k or 'HTML' in k or k in ['Label', 'Password']},
+            progress={k: v for k, v in widget_dict.items() if 'Progress' in k},
+            selects={k: v for k, v in widget_dict.items() if k in ['Dropdown', 'Select', 'SelectMultiple']},
+            media={k: v for k, v in widget_dict.items() if k in ['Audio', 'Image', 'Play', 'Video']}
+        )
+        all_so_far = [name for k, v in groups.items() for name in v.keys()]
+        groups['others'] = {k: v for k, v in widget_dict.items() if k not in all_so_far}
+    elif organize_by == 'module':
+        groups = defaultdict(dict)
+        for k, v in widget_dict.items():
+            module_name = extract_module_name(v)
+            # Grab just the very last part of the module name for a nicer title
+            module_name = module_name.split('_')[-1]
+            groups[module_name][k] = v
+
+    return groups
+
+
+def fill_container(widget, name):
+    """
+    Many of the containers really need special set up; simply adding children does
+    not do the trick. Hide those messy cases in here.
+    """
+    button_lay = widgets.Layout(width="auto", height="auto")
+    if name == "gridspeclayout":
+        for i in range(widget.n_rows):
+            for j in range(widget.n_columns):
+                widget[i, j] = widgets.Button(description='{}, {}'.format(i, j))
+    elif name == "gridbox":
+        widget.layout = widgets.Layout(grid_template_columns="repeat(3, 33%)")
+        widget.children = [widgets.Button(description=str(i),
+                                          layout=button_lay) for i in range(6)]
+    elif name == "twobytwolayout":
+        pass
+        widget.top_left = widgets.Button(description="Top left")
+        widget.top_right = widgets.Button(description="Top right")
+        widget.bottom_left = widgets.Button(description="Bottom left")
+        widget.bottom_right = widgets.Button(description="Bottom right")
+    elif name == "applayout":
+        # So replacing the layouts below with button_lay breaks the AppLayout
+        # widget. No clue why.
+        header        = widgets.Button(description="Header",
+                                       layout=widgets.Layout(width="auto", height="auto"))
+        left_sidebar  = widgets.Button(description="Left Sidebar",
+                                       layout=widgets.Layout(width="auto", height="auto"))
+        center        = widgets.Button(description="Center",
+                                       layout=widgets.Layout(width="auto", height="auto"))
+        right_sidebar = widgets.Button(description="Right Sidebar",
+                                       layout=widgets.Layout(width="auto", height="auto"))
+        footer        = widgets.Button(description="Footer",
+                                       layout=widgets.Layout(width="auto", height="auto"))
+        widget.header = header
+        widget.left_sidebar = left_sidebar
+        widget.center = center
+        widget.right_sidebar = right_sidebar
+        widget.footer = footer
+    else:
+        widget.children = [widgets.Button(description=str(i)) for i in range(3)]
+
+    # Set tab or accordion names
+    if name == "accordion" or name == "tab":
+        titles = [f'{name} {idx}' for idx, _ in enumerate(widget.children)]
+        try:
+            # Retrieve the titles attribute to see if it exists
+            widget.titles
+        except AttributeError:
+            for idx, title in enumerate(titles):
+                widget.set_title(idx, title)
+        else:
+            widget.titles = titles
+
+    # Start with all the accordions closed
+    if name == "accordion":
+        widget.selected_index = None
+
+
+def list_overview_widget(groups,
+                         help_url_base='',
+                         columns=3,
+                         min_width_single_widget=300):
+    """
+    Create an tab-based display of all of the widgets in ``groups``, with
+    a separate tab for each key in groups and links to more detail for each
+    widget. The first line of the docstring of each widget provides a
+    short description of the widget.
+
+    Parameters
+    ----------
+
+    groups : dict
+        Dictionary whose keys are the names of the widget groups and whose
+        values are dictionaries. The dictionaries which are the values of
+        ``groups`` should have the name of the widget to be displayed as
+        the key and the class of the widget as the value.
+    help_url_base : str, optional
+        URL to prepend to the help link for each widget.
+    columns : int, optional
+        Number of columns to use in displaying the widgets.
+    min_width_single_widget : int, optional
+        Minimum width, in pixels, of a widget displayed on a tab.
+
+    Returns
+    -------
+
+    widgets.Tab
+        A ``Tab`` widget with one tab for key of groups in which all of
+        the widgets in that group are displayed.
+    """
+
+    tabs = widgets.Tab()
+
+    if help_url_base is None:
+        help_url_base = 'https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20List.html'
+
+    titles = []
+    kids = []
+
+    def box_maker(name, widget, group):
+        layout = widgets.Layout(grid_template_columns="1fr",
+                                border='2px solid gray')
+        b = widgets.GridBox(layout=layout)
+        module = extract_module_name(widget, full=True)
+
+        if 'selection' in module:
+            extra_args = dict(options=[1, 2, 3])
+        elif 'progress' in widget.__name__.lower():
+            extra_args = dict(value=50)
+        elif 'gridspeclayout' in widget.__name__.lower():
+            extra_args = dict(n_rows=3, n_columns=3)
+        else:
+            extra_args = {}
+
+        wid = widget(description='A label!', **extra_args)
+
+        try:
+            short_description = wid.__doc__.split('\n')[0]
+            if not short_description:
+                short_description = wid.__doc__.split('\n')[1]
+        except AttributeError:
+            short_description = ''
+
+        if group == 'containers':
+            # These look better with things in them but need some custom code
+            fill_container(wid, widget.__name__.lower())
+
+        url = f'{help_url_base}#{name}'
+        help_link = f'<h3><a href="{url}" rel="nofollow" target="_self" style="color:gray;">{name}</a></h3><p>{short_description}</p>'
+        title = widgets.Output()
+        title.append_display_data(HTML(help_link))
+        title.layout.padding = '10px'
+        b.layout.overflow_x = 'hidden'
+        b.children = [title, wid]
+
+        return b
+
+    for group, group_widgets in groups.items():
+        titles.append(group)
+        col_spec = f"repeat({columns}, minmax({min_width_single_widget}px, 1fr)"
+        layout = widgets.Layout(grid_template_columns=col_spec,
+                                grid_gap='10px 10px')
+        kid = widgets.GridBox(layout=layout)
+        kid.children = [box_maker(k, v, group) for k, v in group_widgets.items()]
+        kids.append(kid)
+
+    tabs.children = kids
+
+    try:
+        # Try to access the titles attribute to see if it exists
+        tabs.titles
+    except AttributeError:
+        # We must be using ipywidgets 7, so set_titles
+        for i, title in enumerate(titles):
+            nice = title.replace('_', ' ')
+            tabs.set_title(i, nice.title())
+    else:
+        # We have ipywidgets 8
+        tabs.titles = titles
+
+    return tabs


### PR DESCRIPTION
This PR adds 3 files. Start by taking a look at the one currently named [reference/03.00-widget-list.ipynb](https://github.com/Jupyter4Science/scipy2024-jupyter-widgets-tutorial/compare/main...mwcraig:add-widget-list?expand=1#diff-1b8188ed79dba03158d94b682740efe9932c56dcbbb0f5e55bd6824820b214dc). I strongly recommend that you do that by running the notebook rather than just looking at the code.

The notebook presents a widget which displays all of the widgets in ipywidgets using, of course, some widgets. In that fancy widget, clicking on the name of a widget (e.g. FloatRangeSlider) takes you to a fuller description of the widget.

Potentially useful for giving folks a very quick intro to the types of widget available.